### PR TITLE
Removed unneeed ‘user’ statement.

### DIFF
--- a/apigen.php
+++ b/apigen.php
@@ -15,7 +15,6 @@
 namespace ApiGen;
 
 use Nette\Diagnostics\Debugger;
-use TokenReflection;
 
 if (false === strpos('@php_dir@', '@php_dir')) {
 	// PEAR package


### PR DESCRIPTION
Hi,

I just started studing ApiGen’s code, and KDevelop highlighted a line as “effect-less”. I checked PHP documentation, and I think it is indeed an unneeded line, since the ‘use’ statement is used to import classes, and there it seems to be used to get a whole namespace, which it doesn’t.
