### PR TITLE
Information about the origin of an exception

### DIFF
--- a/apigen.php
+++ b/apigen.php
@@ -223,7 +223,7 @@ try {
 
 		printf("\n\n%s\n", $trace);
 	} else {
-		echo $generator->colorize(sprintf("\n@error@%s@c\n", $e->getMessage()));
+		echo $generator->colorize(sprintf("\n@error@%s@c in %s:%d\n", $e->getMessage(), $e->getFile(), $e->getLine()));
 	}
 
 	die(1);


### PR DESCRIPTION
I modified the file to add information about the origin of an exception.

See my issue https://github.com/apigen/apigen/issues/126
