### PR TITLE
Fixed internal error when no timezone is specified in php.ini

### DIFF
--- a/apigen.php
+++ b/apigen.php
@@ -74,6 +74,12 @@ try {
 	};
 	Debugger::enable(Debugger::PRODUCTION, false);
 
+	// No timezone specified in php.ini
+	$tz = ini_get('date.timezone');
+	if (!$tz) {
+		date_default_timezone_set('UTC');
+	}
+
 	$start = new \DateTime();
 
 	$options = $_SERVER['argv'];


### PR DESCRIPTION
When I have installed apigen and typed "apigen" to shell, this error message occured: "ERROR: the server encountered an internal error and was unable to complete your request."

It's because of following underlying error. No way to debug it without editing the source code.
DateTime::__construct(): It is not safe to rely on the system's timezone settings. You are _required_ to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected 'Europe/Berlin' for 'CEST/2.0/DST' instead

There are also another people having this issue:
https://groups.google.com/forum/?fromgroups#!topic/apigen/PZNGQa-S61I
https://plus.google.com/103970908701054349491/posts/CVBqM6jvjsg

I suggest to set UTC timezone by default if no other is specified in php.ini.
