### PR TITLE
fixed initial selected lines

### DIFF
--- a/templates/bootstrap/js/main.js
+++ b/templates/bootstrap/js/main.js
@@ -230,7 +230,8 @@ $(function() {
 		var lists = matches[0].split(',');
 		for (var i = 0; i < lists.length; i++) {
 			var lines = lists[i].split('-');
-			lines[1] = lines[1] || lines[0];
+			lines[0] = parseInt(lines[0]);
+			lines[1] = parseInt(lines[1] || lines[0]);
 			for (var j = lines[0]; j <= lines[1]; j++) {
 				$('#' + j).addClass('selected');
 			}

--- a/templates/default/js/main.js
+++ b/templates/default/js/main.js
@@ -219,7 +219,8 @@ $(function() {
 		var lists = matches[0].split(',');
 		for (var i = 0; i < lists.length; i++) {
 			var lines = lists[i].split('-');
-			lines[1] = lines[1] || lines[0];
+			lines[0] = parseInt(lines[0]);
+			lines[1] = parseInt(lines[1] || lines[0]);
 			for (var j = lines[0]; j <= lines[1]; j++) {
 				$('#' + j).addClass('selected');
 			}


### PR DESCRIPTION
Before this patch sometimes the lines were not selected, because of string comparison.
Example: `#5-11`
The string "5" is greater than the string "11", so no lines were selected…
