### PR TITLE
Nette misunderstanding syntax in @layout.latte causes total failure.

### DIFF
--- a/templates/bootstrap/@layout.latte
+++ b/templates/bootstrap/@layout.latte
@@ -101,7 +101,8 @@ the file LICENSE.md that was distributed with this source code.
 		{define #group}
 			<ul>
 				{foreach $groups as $group}
-				{var $nextLevel = substr_count($iterator->nextValue, '\\') > substr_count($group, '\\')}
+				{var $groupCount = substr_count($group, '\\')}
+				{var $nextLevel = substr_count($iterator->nextValue, '\\') > $groupCount}
 				<li n:class="$actualGroup === $group || 0 === strpos($actualGroup, $group . '\\') ? active, $config->main && 0 === strpos($group, $config->main) ? main"><a href="{$group|groupUrl}">{$group|subgroupName}{if $nextLevel}<span></span>{/if}</a>
 					{if $nextLevel}
 						<ul>

--- a/templates/default/@layout.latte
+++ b/templates/default/@layout.latte
@@ -48,7 +48,8 @@ the file LICENSE.md that was distributed with this source code.
 		{define #group}
 			<ul>
 				{foreach $groups as $group}
-				{var $nextLevel = substr_count($iterator->nextValue, '\\') > substr_count($group, '\\')}
+				{var $groupCount = substr_count($group, '\\')} 
+				{var $nextLevel = substr_count($iterator->nextValue, '\\') > $groupCount}
 				<li n:class="$actualGroup === $group || 0 === strpos($actualGroup, $group . '\\') ? active, $config->main && 0 === strpos($group, $config->main) ? main"><a href="{$group|groupUrl}">{$group|subgroupName}{if $nextLevel}<span></span>{/if}</a>
 					{if $nextLevel}
 						<ul>


### PR DESCRIPTION
When trying to compile ApiGen documentation using the following command, it errors with a PHP ParseError, due to a ";" inserted instead of left as the "," in the original code.

"apigen.php --source ./app --destination docs/apigen --todo yes --title "My Documentation" --php no --download yes --debug"

Added $groupCount variable to templates/{default,bootstrap}/@layout.latte to avoid Nette template framework from misreading the syntax and inserting an unexpected ;
