### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"ext-json": "*",
 		"ext-mbstring": "*",
 		"nette/nette": ">=2.0.6",
-		"dg/texy": ">=2.1.0",
+		"texy/texy": ">=2.1.0",
 		"kukulich/fshl": ">=2.1.0",
 		"andrewsville/php-token-reflection": ">=1.3.1"
 	},


### PR DESCRIPTION
The package name change to texy/texy:
https://github.com/dg/texy/commit/fc5fc99f40aca133f648f34a9b3fec3ad1302091

... this is no problem at all as long as you're using `packagist`. But `satis` cannot resolve `dg/texy` because it uses the package name from the `composer.json` (from https://github.com/dg/texy/blob/master/composer.json) which is `texy/texy`.
