### PR TITLE
Annotations should be case insensitive

### DIFF
--- a/ApiGen/ReflectionElement.php
+++ b/ApiGen/ReflectionElement.php
@@ -313,7 +313,7 @@ abstract class ReflectionElement extends ReflectionBase
 			static $fileLevel = array('package' => true, 'subpackage' => true, 'author' => true, 'license' => true, 'copyright' => true);
 
 			$annotations = $this->reflection->getAnnotations();
-            $annotations = array_change_key_case($annotations, CASE_LOWER);
+            		$annotations = array_change_key_case($annotations, CASE_LOWER);
 
 			unset($annotations[\TokenReflection\ReflectionAnnotation::SHORT_DESCRIPTION]);
 			unset($annotations[\TokenReflection\ReflectionAnnotation::LONG_DESCRIPTION]);


### PR DESCRIPTION
Annotations should be read as case insensitive.
This is so you can correctly capture E.G todo items that is added in all caps
