### PR TITLE
Check for existence of trait and throw a more meaningful exception than 'Undefined index'

### DIFF
--- a/ApiGen/ReflectionClass.php
+++ b/ApiGen/ReflectionClass.php
@@ -865,6 +865,9 @@ class ReflectionClass extends ReflectionElement
 	{
 		$classes = self::$parsedClasses;
 		return array_map(function(IReflectionClass $class) use ($classes) {
+			if (!isset($classes[$class->getName()])) {
+				throw new InvalidArgumentException(sprintf('The class %s is in use but has not been found in the defined sources.', $class->getName()));
+			}
 			return $classes[$class->getName()];
 		}, $this->reflection->getOwnTraits());
 	}


### PR DESCRIPTION
Issue #234 shows, that on the first glance the error message _"exception 'Nette\FatalErrorException' with message 'Undefined index: FlorianWolters\Component\Core\CloneNotSupportedTrait' in C:\dev\apigen\ApiGen\ReflectionClass.php:873"_ is confusing for the user. It was the same for me.

So I want to improve this part with this pull request, so that the user gets an idea how to solve the issue.
