### PR TITLE
 Replace search button with placeholder text in default theme 

### DIFF
--- a/templates/default/@layout.latte
+++ b/templates/default/@layout.latte
@@ -116,8 +116,7 @@ the file LICENSE.md that was distributed with this source code.
 	<form{if $config->googleCseId} action="http://www.google.com/cse"{/if} id="search">
 		<input type="hidden" name="cx" value="{$config->googleCseId}">
 		<input type="hidden" name="ie" value="UTF-8">
-		<input type="text" name="q" class="text"{if 'overview' === $active} autofocus{/if}>
-		<input type="submit" value="Search">
+		<input type="text" name="q" class="text" placeholder="Search"{if 'overview' === $active} autofocus{/if}>
 	</form>
 
 	<div id="navigation">


### PR DESCRIPTION
This causes the default theme to match the Bootstrap theme a little more
closely, and it's good because the search button is nonfunctional unless
Google Custom Search is configured.

Closes #295

Thank you TomasVotruba for the helpful suggestion to find inspiration in templates/bootstrap/@layout.latte.
