### PR TITLE
Added support for custum vendor dir

### DIFF
--- a/apigen
+++ b/apigen
@@ -15,7 +15,19 @@ use TokenReflection;
 use Tracy\Debugger;
 
 
-require_once 'vendor/autoload.php';
+// autoloader's loading path
+$autoloaders = array(
+	'vendor/autoload.php',
+	__DIR__ . '/vendor/autoload.php',
+	__DIR__ . '/../../autoload.php',
+);
+// autoload
+foreach ($autoloaders as $file) {
+	if (file_exists($file)) {
+		require_once $file;
+		break;
+	}
+}
 
 // Safe locale and timezone
 setlocale(LC_ALL, 'C');


### PR DESCRIPTION
I used custom verndor dir,  like this.

composer.json

```
 "config": {
     "vendor-dir": "app/Vendor/Composer"
  }
```

-> install on  "app/Vendor/Composer/apigen/"

in this case, require path is not to be 'vendor/autoloader.php'.
I tryed to fix, I would appreciate it if you merge.

Warm Regards.
