### PR TITLE
@link accepts any URI scheme.

### DIFF
--- a/src/ApiGen/Templating/Template.php
+++ b/src/ApiGen/Templating/Template.php
@@ -141,7 +141,7 @@ class Template extends Nette\Templating\FileTemplate
 					return $that->link($url, $description ?: $url);
 				case 'link':
 					list($url, $description) = $that->split($value);
-					if (Nette\Utils\Validators::isUrl($url)) {
+					if (Nette\Utils\Validators::isUri($url)) {
 						return $that->link($url, $description ?: $url);
 					}
 					break;


### PR DESCRIPTION
`@link` is restricted to the http(s) schemes only. I would love to see `@link` generating links to any URI scheme (e.g. bitcoin:1335STSwu9hST4vcMRppEPgENMHD2r1REK).
