### PR TITLE
doubled 'v' in version name

### DIFF
--- a/src/ApiGen/Command/SelfUpdateCommand.php
+++ b/src/ApiGen/Command/SelfUpdateCommand.php
@@ -66,7 +66,7 @@ EOT
 	 */
 	private function downloadFile(OutputInterface $output, $item)
 	{
-		$output->writeln('<info>Downloading ApiGen v' . $item->version . '...</info>');
+		$output->writeln('<info>Downloading ApiGen ' . $item->version . '...</info>');
 		file_put_contents($this->getTempFilename(), file_get_contents($item->url));
 		$this->validateFileChecksum($output, $item);
 		rename($this->getTempFilename(), $this->getLocalFilename());


### PR DESCRIPTION
Also an error occured after update succeeded. 

```
# apigen selfupdate
Downloading ApiGen vv4.0.0-RC3...
Checking file checksum...
Making ApiGen executable...
ApiGen updated!
ERROR: application encountered an error and can not continue.
```
