### PR TITLE
relative path problems (windows)

### DIFF
--- a/tests/ApiGenTests/bootstrap.php
+++ b/tests/ApiGenTests/bootstrap.php
@@ -20,8 +20,8 @@ define('TEMP_DIR', createTempDir());
 Tracy\Debugger::$logDirectory = TEMP_DIR;
 
 
-define('PROJECT_DIR', __DIR__ . DS . '../Project');
-define('PROJECT_BETA_DIR', __DIR__ . DS . '../ProjectBeta');
+define('PROJECT_DIR', realpath( __DIR__ . DS . '../Project' ));
+define('PROJECT_BETA_DIR', realpath( __DIR__ . DS . '../ProjectBeta' ));
 define('API_DIR', TEMP_DIR . DS . 'api');
 define('APIGEN_BIN', 'php ' . realpath(__DIR__ . '/../../src/apigen.php'));
 

--- a/tests/php-win.ini
+++ b/tests/php-win.ini
@@ -1,0 +1,5 @@
+[PHP]
+max_execution_time=90
+
+[Phar]
+phar.readonly=off


### PR DESCRIPTION
local tests under windows have problems with relative paths.
e.g.:

```
Could not determine "C:\path\to\apigen\tests\ApiGenTests\..\ProjectBeta\Article.php" relative path
```
