### PR TITLE
Text align in todo tasks

### DIFF
--- a/src/templates/bootstrap/resources/style.css
+++ b/src/templates/bootstrap/resources/style.css
@@ -282,6 +282,10 @@ h2.switchable {
 	text-align: right;
 }
 
+.summary td hr {
+	margin: 8px -8px;
+}
+
 #packages.summary td:first-child, #namespaces.summary td:first-child, .inherited.summary td:first-child, .used.summary td:first-child {
 	text-align: left;
 }

--- a/src/templates/bootstrap/todo.latte
+++ b/src/templates/bootstrap/todo.latte
@@ -10,12 +10,14 @@
 	{define classes}
 		{foreach $items as $class}
 			<tr>
-				<td class="name right" rowspan="{count($class->annotations['todo'])}">
+				<td class="name right">
 					<a href="{$class|classUrl}">{$class->name}</a>
 				</td>
-				{foreach $class->annotations['todo'] as $description}
-					<td class="left">{$description|annotation:'todo':$class|noescape}</td>{sep}</tr><tr>{/sep}
-				{/foreach}
+				<td>
+					{foreach $class->annotations['todo'] as $description}
+						{$description|annotation:'todo':$class|noescape}{sep}<hr>{/sep}
+					{/foreach}
+				</td>
 			</tr>
 		{/foreach}
 	{/define}
@@ -53,12 +55,13 @@
 		<table class="summary table table-bordered table-striped" id="methods">
 			{foreach $todoMethods as $method}
 				<tr>
-					{var $count = count($method->annotations['todo'])}
-					<td class="name" rowspan="{$count}"><a href="{$method->declaringClassName|classUrl}">{$method->declaringClassName}</a></td>
-					<td class="name" rowspan="{$count}"><code><a href="{$method|methodUrl}">{$method->name}()</a></code></td>
-					{foreach $method->annotations['todo'] as $description}
-						<td>{$description|annotation:'todo':$method|noescape}</td>{sep}</tr><tr>{/sep}
-					{/foreach}
+					<td class="name"><a href="{$method->declaringClassName|classUrl}">{$method->declaringClassName}</a></td>
+					<td class="name"><code><a href="{$method|methodUrl}">{$method->name}()</a></code></td>
+					<td>
+						{foreach $method->annotations['todo'] as $description}
+							{$description|annotation:'todo':$method|noescape}{sep}<hr>{/sep}
+						{/foreach}
+					</td>
 				</tr>
 			{/foreach}
 		</table>
@@ -69,17 +72,18 @@
 		<table class="summary table table-bordered table-striped" id="constants">
 			{foreach $todoConstants as $constant}
 			<tr>
-				{var $count = count($constant->annotations['todo'])}
 				{if $constant->declaringClassName}
-					<td class="name" rowspan="{$count}"><a href="{$constant->declaringClassName|classUrl}">{$constant->declaringClassName}</a></td>
-					<td class="name" rowspan="{$count}"><code><a href="{$constant|constantUrl}"><b>{$constant->name}</b></a></code></td>
+					<td class="name"><a href="{$constant->declaringClassName|classUrl}">{$constant->declaringClassName}</a></td>
+					<td class="name"><code><a href="{$constant|constantUrl}"><b>{$constant->name}</b></a></code></td>
 				{else}
-					<td class="name" rowspan="{$count}" n:if="$namespaces || $classes || $interfaces || $traits || $exceptions"><a n:if="$constant->namespaceName" href="{$constant->namespaceName|namespaceUrl}">{$constant->namespaceName}</a></td>
-					<td n:class="name" rowspan="{$count}"><code><a href="{$constant|constantUrl}"><b>{$constant->shortName}</b></a></code></td>
+					<td class="name" n:if="$namespaces || $classes || $interfaces || $traits || $exceptions"><a n:if="$constant->namespaceName" href="{$constant->namespaceName|namespaceUrl}">{$constant->namespaceName}</a></td>
+					<td n:class="name"><code><a href="{$constant|constantUrl}"><b>{$constant->shortName}</b></a></code></td>
 				{/if}
-				{foreach $constant->annotations['todo'] as $description}
-					<td>{$description|annotation:'todo':$constant|noescape}</td>{sep}</tr><tr>{/sep}
-				{/foreach}
+				<td>
+					{foreach $constant->annotations['todo'] as $description}
+						{$description|annotation:'todo':$constant|noescape}{sep}<hr>{/sep}
+					{/foreach}
+				</td>
 			</tr>
 			{/foreach}
 		</table>
@@ -90,12 +94,13 @@
 		<table class="summary table table-bordered table-striped" id="properties">
 			{foreach $todoProperties as $property}
 				<tr>
-					{var $count = count($property->annotations['todo'])}
-					<td class="name" rowspan="{$count}"><a href="{$property->declaringClassName|classUrl}">{$property->declaringClassName}</a></td>
-					<td class="name" rowspan="{$count}"><a href="{$property|propertyUrl}"><var>${$property->name}</var></a></td>
-					{foreach $property->annotations['todo'] as $description}
-						<td>{$description|annotation:'todo':$property|noescape}</td>{sep}</tr><tr>{/sep}
-					{/foreach}
+					<td class="name"><a href="{$property->declaringClassName|classUrl}">{$property->declaringClassName}</a></td>
+					<td class="name"><a href="{$property|propertyUrl}"><var>${$property->name}</var></a></td>
+					<td>
+						{foreach $property->annotations['todo'] as $description}
+							{$description|annotation:'todo':$property|noescape}{sep}<hr>{/sep}
+						{/foreach}
+					</td>
 				</tr>
 			{/foreach}
 		</table>
@@ -106,12 +111,13 @@
 			<table class="summary table table-bordered table-striped" id="functions">
 			{foreach $todoFunctions as $function}
 				<tr>
-					{var $count = count($function->annotations['todo'])}
-					<td class="name" rowspan="{$count}" n:if="$namespaces"><a n:if="$function->namespaceName" href="{$function->namespaceName|namespaceUrl}">{$function->namespaceName}</a></td>
-					<td class="name" rowspan="{$count}"><code><a href="{$function|functionUrl}">{$function->shortName}</a></code></td>
-					{foreach $function->annotations['todo'] as $description}
-						<td>{$description|annotation:'todo':$function|noescape}</td>{sep}</tr><tr>{/sep}
-					{/foreach}
+					<td class="name" n:if="$namespaces"><a n:if="$function->namespaceName" href="{$function->namespaceName|namespaceUrl}">{$function->namespaceName}</a></td>
+					<td class="name"><code><a href="{$function|functionUrl}">{$function->shortName}</a></code></td>
+					<td>
+						{foreach $function->annotations['todo'] as $description}
+							{$description|annotation:'todo':$function|noescape}{sep}<hr>{/sep}
+						{/foreach}
+					</td>
 				</tr>
 			{/foreach}
 		</table>

--- a/src/templates/default/resources/style.css
+++ b/src/templates/default/resources/style.css
@@ -363,6 +363,10 @@ dl.tree dd {
 	text-align: right;
 }
 
+.summary td hr {
+	margin: 3px -10px;
+}
+
 #packages.summary td:first-child, #namespaces.summary td:first-child, .inherited.summary td:first-child, .used.summary td:first-child {
 	text-align: left;
 }

--- a/src/templates/default/todo.latte
+++ b/src/templates/default/todo.latte
@@ -10,12 +10,14 @@
 	{define classes}
 		{foreach $items as $class}
 			<tr>
-				<td class="name right" rowspan="{count($class->annotations['todo'])}">
+				<td class="name right">
 					<a href="{$class|classUrl}">{$class->name}</a>
 				</td>
-				{foreach $class->annotations['todo'] as $description}
-					<td class="left">{$description|annotation:'todo':$class|noescape}</td>{sep}</tr><tr>{/sep}
-				{/foreach}
+				<td>
+					{foreach $class->annotations['todo'] as $description}
+						{$description|annotation:'todo':$class|noescape}{sep}<hr>{/sep}
+					{/foreach}
+				</td>
 			</tr>
 		{/foreach}
 	{/define}
@@ -44,12 +46,13 @@
 		<caption>Methods summary</caption>
 		{foreach $todoMethods as $method}
 			<tr>
-				{var $count = count($method->annotations['todo'])}
-				<td class="name" rowspan="{$count}"><a href="{$method->declaringClassName|classUrl}">{$method->declaringClassName}</a></td>
-				<td class="name" rowspan="{$count}"><code><a href="{$method|methodUrl}">{$method->name}()</a></code></td>
-				{foreach $method->annotations['todo'] as $description}
-					<td>{$description|annotation:'todo':$method|noescape}</td>{sep}</tr><tr>{/sep}
-				{/foreach}
+				<td class="name"><a href="{$method->declaringClassName|classUrl}">{$method->declaringClassName}</a></td>
+				<td class="name"><code><a href="{$method|methodUrl}">{$method->name}()</a></code></td>
+				<td>
+					{foreach $method->annotations['todo'] as $description}
+						{$description|annotation:'todo':$method|noescape}{sep}<hr>{/sep}
+					{/foreach}
+				</td>
 			</tr>
 		{/foreach}
 	</table>
@@ -58,18 +61,19 @@
 		<caption>Constants summary</caption>
 		{foreach $todoConstants as $constant}
 			<tr>
-				{var $count = count($constant->annotations['todo'])}
 				{if $constant->declaringClassName}
-					<td class="name" rowspan="{$count}"><a href="{$constant->declaringClassName|classUrl}">{$constant->declaringClassName}</a></td>
-					<td class="name" rowspan="{$count}"><code><a href="{$constant|constantUrl}"><b>{$constant->name}</b></a></code></td>
+					<td class="name"><a href="{$constant->declaringClassName|classUrl}">{$constant->declaringClassName}</a></td>
+					<td class="name"><code><a href="{$constant|constantUrl}"><b>{$constant->name}</b></a></code></td>
 				{else}
-					<td class="name" rowspan="{$count}" n:if="$namespaces || $classes || $interfaces || $traits || $exceptions"><a n:if="$constant->namespaceName" href="{$constant->namespaceName|namespaceUrl}">{$constant->namespaceName}</a></td>
-					<td n:class="name" rowspan="{$count}"><code><a href="{$constant|constantUrl}"><b>{$constant->shortName}</b></a></code></td>
+					<td class="name" n:if="$namespaces || $classes || $interfaces || $traits || $exceptions"><a n:if="$constant->namespaceName" href="{$constant->namespaceName|namespaceUrl}">{$constant->namespaceName}</a></td>
+					<td n:class="name"><code><a href="{$constant|constantUrl}"><b>{$constant->shortName}</b></a></code></td>
 				{/if}
 
-				{foreach $constant->annotations['todo'] as $description}
-					<td>{$description|annotation:'todo':$constant|noescape}</td>{sep}</tr><tr>{/sep}
-				{/foreach}
+				<td>
+					{foreach $constant->annotations['todo'] as $description}
+						{$description|annotation:'todo':$constant|noescape}{sep}<hr>{/sep}
+					{/foreach}
+				</td>
 			</tr>
 		{/foreach}
 	</table>
@@ -78,12 +82,13 @@
 		<caption>Properties summary</caption>
 		{foreach $todoProperties as $property}
 			<tr>
-				{var $count = count($property->annotations['todo'])}
-				<td class="name" rowspan="{$count}"><a href="{$property->declaringClassName|classUrl}">{$property->declaringClassName}</a></td>
-				<td class="name" rowspan="{$count}"><a href="{$property|propertyUrl}"><var>${$property->name}</var></a></td>
-				{foreach $property->annotations['todo'] as $description}
-					<td>{$description|annotation:'todo':$property|noescape}</td>{sep}</tr><tr>{/sep}
-				{/foreach}
+				<td class="name"><a href="{$property->declaringClassName|classUrl}">{$property->declaringClassName}</a></td>
+				<td class="name"><a href="{$property|propertyUrl}"><var>${$property->name}</var></a></td>
+				<td>
+					{foreach $property->annotations['todo'] as $description}
+						{$description|annotation:'todo':$property|noescape}{sep}<hr>{/sep}
+					{/foreach}
+				</td>
 			</tr>
 		{/foreach}
 	</table>
@@ -92,12 +97,13 @@
 		<caption>Functions summary</caption>
 		{foreach $todoFunctions as $function}
 			<tr>
-				{var $count = count($function->annotations['todo'])}
-				<td class="name" rowspan="{$count}" n:if="$namespaces"><a n:if="$function->namespaceName" href="{$function->namespaceName|namespaceUrl}">{$function->namespaceName}</a></td>
-				<td class="name" rowspan="{$count}"><code><a href="{$function|functionUrl}">{$function->shortName}</a></code></td>
-				{foreach $function->annotations['todo'] as $description}
-					<td>{$description|annotation:'todo':$function|noescape}</td>{sep}</tr><tr>{/sep}
-				{/foreach}
+				<td class="name" n:if="$namespaces"><a n:if="$function->namespaceName" href="{$function->namespaceName|namespaceUrl}">{$function->namespaceName}</a></td>
+				<td class="name"><code><a href="{$function|functionUrl}">{$function->shortName}</a></code></td>
+				<td>
+					{foreach $function->annotations['todo'] as $description}
+						{$description|annotation:'todo':$function|noescape}{sep}<hr>{/sep}
+					{/foreach}
+				</td>
 			</tr>
 		{/foreach}
 	</table>


### PR DESCRIPTION
**Former state was:** second, third and next task was text align to right. And tasks were in more table row (_tr_).
**Now:** Now is all text align left and in one row (_tr_).

Please, compare now state with prepare state. Examples file for testing are here:

``` php
<?php

/**                                                                                                                                                                               
 * My constant.
 * @todo First todo.
 * @todo Second todo.
 * @todo Third todo.
 */
const MY_CONST = 123;

/**
 * Return anything value.
 * @todo First comment in function.
 * @todo Second comment in function.
 * @todo Third todo comment in function.
 */
function test() {
        return 1;
}
```

and 

``` php
<?php                                                                                                                                                                             

/**
 * @todo First todo.
 * @todo Second todo.
 * @todo Third todo.
 */
class MyClass {
        /**
         * @todo First todo.
         * @todo Second todo.
         * @todo Third todo.
         */
        const MY_CONST = 123;

        /**
         * @todo First todo.
         * @todo Second todo.
         * @todo Third todo.
         */
        private $property = 123;
        /**
         * @todo First todo.
         * @todo Second todo.
         * @todo Third todo.
         */
        private function method()
        {
                return 123;
        }
}


/**
 * @todo First todo.
 * @todo Second todo.
 * @todo Third todo.
 */
interface MyInterface {

}


/**
 * @todo First todo.
 * @todo Second todo.
 * @todo Third todo.
 */
trait MyTrait {

}


/**
 * @todo First todo.
 * @todo Second todo.
 * @todo Third todo.
 */
class MyException extends Exception {}
```
