### PR TITLE
Parser: Adds unit tests for PHP 5.6 features

### DIFF
--- a/tests/Parser/Broker/BackendSourcePhp56DefaultArguments/DefaultArguments.php
+++ b/tests/Parser/Broker/BackendSourcePhp56DefaultArguments/DefaultArguments.php
@@ -1,0 +1,24 @@
+<?php
+
+const GLOBAL_CONST = 1;
+
+
+abstract class SomeClass
+{
+
+    const CLASS_CONST = 2;
+
+}
+
+
+function classConst($agr1, $arg2 = SomeClass::CLASS_CONST)
+{
+
+}
+
+
+function globalConst($arg = GLOBAL_CONST)
+{
+
+}
+

--- a/tests/Parser/Broker/BackendSourcePhp56Namespaces/Namespaces.php
+++ b/tests/Parser/Broker/BackendSourcePhp56Namespaces/Namespaces.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace some\Name\space
+{
+
+    const SOME_CONSTANT = 2 * 3;
+
+
+    define('OTHER_CONSTANT', 2);
+
+
+    function someAloneFunction()
+    {
+
+    }
+
+
+    function someOtherFunction()
+    {
+
+    }
+
+}
+
+
+namespace some\Other\space
+{
+
+    use function \some\Name\space\someOtherFunction;
+    use function \some\Name\space\someAloneFunction as someFunction;
+    use const some\Name\space\SOME_CONSTANT;
+    use const some\Name\space\OTHER_CONSTANT as SECOND_NAME;
+
+
+    function someAloneFunction()
+    {
+        someFunction();
+        someOtherFunction();
+    }
+
+}
+

--- a/tests/Parser/Broker/BackendSourcePhp56VariadicFunctions/VariadicFunctions.php
+++ b/tests/Parser/Broker/BackendSourcePhp56VariadicFunctions/VariadicFunctions.php
@@ -1,0 +1,18 @@
+<?php
+
+function complexParameters($reqArg, $optArg = null, ...$variadicArgs)
+{
+
+}
+
+
+function simpleParameters(...$variadicArgs)
+{
+
+}
+
+
+function typehintedParameters(callable ...$variadicArgs)
+{
+
+}

--- a/tests/Parser/Broker/BackendTest.php
+++ b/tests/Parser/Broker/BackendTest.php
@@ -110,7 +110,7 @@ class BackendTest extends PHPUnit_Framework_TestCase
 	}
 
 
-        public function atestPhp56Namespaces()
+        public function testPhp56Namespaces()
 	{
 		$this->broker->processDirectory(__DIR__ . '/BackendSourcePhp56Namespaces');
 
@@ -133,7 +133,7 @@ class BackendTest extends PHPUnit_Framework_TestCase
 	}
 
 
-        public function atestPhp56VariadicFunctions()
+        public function testPhp56VariadicFunctions()
 	{
 		$this->broker->processDirectory(__DIR__ . '/BackendSourcePhp56VariadicFunctions');
 		$functions = $this->backend->getFunctions();

--- a/tests/Parser/Broker/BackendTest.php
+++ b/tests/Parser/Broker/BackendTest.php
@@ -78,6 +78,74 @@ class BackendTest extends PHPUnit_Framework_TestCase
 	}
 
 
+        public function testPhp56DefaultArguments()
+	{
+		$this->broker->processDirectory(__DIR__ . '/BackendSourcePhp56DefaultArguments');
+
+		$functions = $this->backend->getFunctions();
+		$this->assertCount(2, $functions);
+
+                foreach ($functions as $function) {
+                    $this->assertInstanceOf('ApiGen\Reflection\ReflectionFunction', $function);
+                    $this->checkLoadedProperties($function);
+                }
+
+		$constants = $this->backend->getConstants();
+                $this->assertCount(1, $constants);
+
+                foreach ($constants as $constant)
+                {
+                    $this->assertInstanceOf('ApiGen\Reflection\ReflectionConstant', $constant);
+                    $this->checkLoadedProperties($constant);
+                }
+
+                $classes = $this->backend->getClasses();
+                $this->assertCount(1, $classes);
+
+                foreach ($classes as $class)
+                {
+                    $this->assertInstanceOf('ApiGen\Reflection\ReflectionConstant', $constant);
+                    $this->checkLoadedProperties($constant);
+                }
+	}
+
+
+        public function atestPhp56Namespaces()
+	{
+		$this->broker->processDirectory(__DIR__ . '/BackendSourcePhp56Namespaces');
+
+		$functions = $this->backend->getFunctions();
+		$this->assertCount(3, $functions);
+
+                foreach ($functions as $function) {
+                    $this->assertInstanceOf('ApiGen\Reflection\ReflectionFunction', $function);
+                    $this->checkLoadedProperties($function);
+                }
+
+		$constants = $this->backend->getConstants();
+                $this->assertCount(2, $constants);
+
+                foreach ($constants as $constant)
+                {
+                    $this->assertInstanceOf('ApiGen\Reflection\ReflectionConstant', $constant);
+                    $this->checkLoadedProperties($constant);
+                }
+	}
+
+
+        public function atestPhp56VariadicFunctions()
+	{
+		$this->broker->processDirectory(__DIR__ . '/BackendSourcePhp56VariadicFunctions');
+		$functions = $this->backend->getFunctions();
+		$this->assertCount(2, $functions);
+
+		$function = array_pop($functions);
+		$this->assertInstanceOf('ApiGen\Reflection\ReflectionFunction', $function);
+
+		$this->checkLoadedProperties($function);
+	}
+
+
 	private function checkLoadedProperties($object)
 	{
 		$this->assertInstanceOf(


### PR DESCRIPTION
This unit tests should cover all relevant PHP 5.6 features. 2/3 are currently failing. The pullrequest is in response to https://github.com/apigen/apigen/issues/494, https://github.com/apigen/apigen/issues/495 
