### PR TITLE
Added expand/collapse toggle to descriptions

### DIFF
--- a/src/templates/bootstrap/js/main.js
+++ b/src/templates/bootstrap/js/main.js
@@ -130,11 +130,19 @@ $(window).load(function() {
 
 	// Open details
 	if (ApiGen.config.options.elementDetailsCollapsed) {
+		var trCollapsed = true;
 		$('tr', $content).filter(':has(.detailed)')
 			.click(function() {
 				var $this = $(this);
-				$('.short', $this).hide();
-				$('.detailed', $this).show();
+				if (trCollapsed) {
+					$('.short', $this).hide();
+					$('.detailed', $this).show();
+					trCollapsed = false;
+				} else {					
+					$('.short', $this).show();
+					$('.detailed', $this).hide();
+					trCollapsed = true;
+				}
 			});
 	}
 

--- a/src/templates/default/js/main.js
+++ b/src/templates/default/js/main.js
@@ -130,11 +130,19 @@ $(window).load(function() {
 
 	// Open details
 	if (ApiGen.config.options.elementDetailsCollapsed) {
+		var trCollapsed = true;
 		$('tr', $content).filter(':has(.detailed)')
 			.click(function() {
 				var $this = $(this);
-				$('.short', $this).hide();
-				$('.detailed', $this).show();
+				if (trCollapsed) {
+					$('.short', $this).hide();
+					$('.detailed', $this).show();
+					trCollapsed = false;
+				} else {					
+					$('.short', $this).show();
+					$('.detailed', $this).hide();
+					trCollapsed = true;
+				}
 			});
 	}
 


### PR DESCRIPTION
I've always liked ApiGen since the first time I used it (v2.8) and the only one whine I have ever really had about it was the inability to collapse a description for methods/properties after expanding them.  

A particular page of the documentation can get crowded fairly quickly as multiple rows are expanded and in my opinion the readability suffers because they can not be collapsed afterwards.

After reviewing previous issues I found that this has been brought up in the past in issue #215 which has been closed because it had gone stale and there was no PR for it.  After digging through some of the theme files I found a block of code in `main.js`  that has the code to expand those descriptions.  I've updated it to add a toggling effect.  I made the change on both the default and bootstrap themes.

Hope it is useful and can be merged in with the next release.