### PR TITLE
Added highlight effect for contents targeted by #hash-fragments in URLs ...

### DIFF
--- a/src/templates/default/resources/style.css
+++ b/src/templates/default/resources/style.css
@@ -1,3 +1,39 @@
+@keyframes highlightTargetBackground {
+	0% {
+		background:inherit;
+	}
+	50% {
+		background:#7fb4f5;
+	}
+	100% {
+		background:inherit;
+	}
+}
+
+@-webkit-keyframes highlightTargetBackground {
+	0% {
+		background:inherit;
+	}
+	50% {
+		background:#7fb4f5;
+	}
+	100% {
+		background:inherit;
+	}
+}
+
+@-moz-keyframes highlightTargetBackground {
+	0% {
+		background:inherit;
+	}
+	50% {
+		background:#7fb4f5;
+	}
+	100% {
+		background:inherit;
+	}
+}
+
 body {
 	font: 13px/1.5 Verdana, 'Geneva CE', lucida, sans-serif;
 	margin: 0;
@@ -349,6 +385,12 @@ dl.tree dd {
 .summary caption.switchable {
 	background: #ecede5 url('sort.png') no-repeat center right;
 	cursor: pointer;
+}
+
+.summary tr:target {
+	-webkit-animation: highlightTargetBackground 1s ease-in-out 0.2s;
+	-moz-animation: highlightTargetBackground 1s ease-in-out 0.2s;
+	animation: highlightTargetBackground 1s ease-in-out 0.2s;
 }
 
 .summary td {


### PR DESCRIPTION
...via the CSS3 :target pseudo-state. Improves readability a lot.

The improvement includes also the `highlightTargetBackground` animation keyframes in a way that could be reused by other similar purposes.

Tested to be working in recent browsers and ignored by older ones.