### PR TITLE
Two fixes related to element types

### DIFF
--- a/src/ApiGen/Parser/Elements/ElementStorage.php
+++ b/src/ApiGen/Parser/Elements/ElementStorage.php
@@ -233,7 +233,7 @@ class ElementStorage
 					$this->traits[$elementName] = $element;
 
 				} elseif ($element->isException()) {
-					$elementType = Elements::INTERFACES;
+					$elementType = Elements::EXCEPTIONS;
 					$this->exceptions[$elementName] = $element;
 
 				} else {

--- a/src/ApiGen/Templating/TemplateElementsLoader.php
+++ b/src/ApiGen/Templating/TemplateElementsLoader.php
@@ -61,7 +61,7 @@ class TemplateElementsLoader
 			'namespaces' => array_keys($this->elementStorage->getNamespaces()),
 			'packages' => array_keys($this->elementStorage->getPackages()),
 			'classes' => array_filter($this->elementStorage->getClasses(), $this->getMainFilter()),
-			'interfaces' => array_filter($this->elementStorage->getClasses(), $this->getMainFilter()),
+			'interfaces' => array_filter($this->elementStorage->getInterfaces(), $this->getMainFilter()),
 			'traits' => array_filter($this->elementStorage->getTraits(), $this->getMainFilter()),
 			'exceptions' => array_filter($this->elementStorage->getExceptions(), $this->getMainFilter()),
 			'constants' => array_filter($this->elementStorage->getConstants(), $this->getMainFilter()),

--- a/tests/Templating/TemplateElementsLoaderTest.php
+++ b/tests/Templating/TemplateElementsLoaderTest.php
@@ -71,7 +71,7 @@ class TemplateElementsLoaderTest extends PHPUnit_Framework_TestCase
 		$elementStorageMock->shouldReceive('getNamespaces')->andReturn([]);
 		$elementStorageMock->shouldReceive('getPackages')->andReturn([]);
 		$elementStorageMock->shouldReceive('getClasses')->andReturn([]);
-		$elementStorageMock->shouldReceive('getClasses')->andReturn([]);
+		$elementStorageMock->shouldReceive('getInterfaces')->andReturn([]);
 		$elementStorageMock->shouldReceive('getTraits')->andReturn([]);
 		$elementStorageMock->shouldReceive('getExceptions')->andReturn([]);
 		$elementStorageMock->shouldReceive('getConstants')->andReturn([]);


### PR DESCRIPTION
Found these attempting to track down why exceptions were displayed as interfaces. The ElementStorage patch fixed my issue.