### PR TITLE
Support static magic method

### DIFF
--- a/src/Reflection/Extractors/AnnotationMethodExtractor.php
+++ b/src/Reflection/Extractors/AnnotationMethodExtractor.php
@@ -17,7 +17,7 @@ use ApiGen\Reflection\TokenReflection\ReflectionFactory;
 class AnnotationMethodExtractor
 {
 
-	const PATTERN_METHOD = '~^(?:([\\w\\\\]+(?:\\|[\\w\\\\]+)*)\\s+)?(&)?\\s*(\\w+)\\s*\\(\\s*(.*)\\s*\\)\\s*(.*|$)~s';
+	const PATTERN_METHOD = '~^(?:(static)\\s+)?(?:([\\w\\\\]+(?:\\|[\\w\\\\]+)*)\\s+)?(&)?\\s*(\\w+)\\s*\\(\\s*(.*)\\s*\\)\\s*(.*|$)~s';
 	const PATTERN_PARAMETER = '~^(?:([\\w\\\\]+(?:\\|[\\w\\\\]+)*)\\s+)?(&)?\\s*\\$(\\w+)(?:\\s*=\\s*(.*))?($)~s';
 
 	/**
@@ -66,7 +66,7 @@ class AnnotationMethodExtractor
 			return [];
 		}
 
-		list(, $returnTypeHint, $returnsReference, $name, $args, $shortDescription) = $matches;
+		list(, $static, $returnTypeHint, $returnsReference, $name, $args, $shortDescription) = $matches;
 
 		$startLine = $this->getStartLine($annotation);
 		$endLine = $startLine + substr_count($annotation, "\n");
@@ -79,7 +79,8 @@ class AnnotationMethodExtractor
 			'endLine' => $endLine,
 			'returnsReference' => ($returnsReference === '&'),
 			'declaringClass' => $this->reflectionClass,
-			'annotations' => ['return' => [0 => $returnTypeHint]]
+			'annotations' => ['return' => [0 => $returnTypeHint]],
+			'static' => ($static === 'static')
 		]);
 		$this->attachMethodParameters($method, $args);
 		return $methods;

--- a/src/Reflection/Extractors/AnnotationMethodExtractor.php
+++ b/src/Reflection/Extractors/AnnotationMethodExtractor.php
@@ -17,7 +17,8 @@ use ApiGen\Reflection\TokenReflection\ReflectionFactory;
 class AnnotationMethodExtractor
 {
 
-	const PATTERN_METHOD = '~^(?:(static)\\s+)?(?:([\\w\\\\]+(?:\\|[\\w\\\\]+)*)\\s+)?(&)?\\s*(\\w+)\\s*\\(\\s*(.*)\\s*\\)\\s*(.*|$)~s';
+	const PATTERN_METHOD
+		= '~^(?:(static)\\s+)?(?:([\\w\\\\]+(?:\\|[\\w\\\\]+)*)\\s+)?(&)?\\s*(\\w+)\\s*\\(\\s*(.*)\\s*\\)\\s*(.*|$)~s';
 	const PATTERN_PARAMETER = '~^(?:([\\w\\\\]+(?:\\|[\\w\\\\]+)*)\\s+)?(&)?\\s*\\$(\\w+)(?:\\s*=\\s*(.*))?($)~s';
 
 	/**

--- a/src/Reflection/ReflectionMethodMagic.php
+++ b/src/Reflection/ReflectionMethodMagic.php
@@ -42,11 +42,11 @@ class ReflectionMethodMagic extends ReflectionMethod
 	 */
 	private $declaringClass;
 
-
 	/**
 	 * @var bool
 	 */
 	private $static;
+
 
 	public function __construct(array $settings)
 	{
@@ -57,7 +57,7 @@ class ReflectionMethodMagic extends ReflectionMethod
 		$this->returnsReference = $settings['returnsReference'];
 		$this->declaringClass = $settings['declaringClass'];
 		$this->annotations = $settings['annotations'];
-		$this->static = isset($settings['static'])?$settings['static']:false;
+		$this->static = isset($settings['static']) ? $settings['static'] : FALSE;
 
 		$this->reflectionType = get_class($this);
 	}

--- a/src/Reflection/ReflectionMethodMagic.php
+++ b/src/Reflection/ReflectionMethodMagic.php
@@ -43,6 +43,11 @@ class ReflectionMethodMagic extends ReflectionMethod
 	private $declaringClass;
 
 
+	/**
+	 * @var bool
+	 */
+	private $static;
+
 	public function __construct(array $settings)
 	{
 		$this->name = $settings['name'];
@@ -52,6 +57,7 @@ class ReflectionMethodMagic extends ReflectionMethod
 		$this->returnsReference = $settings['returnsReference'];
 		$this->declaringClass = $settings['declaringClass'];
 		$this->annotations = $settings['annotations'];
+		$this->static = isset($settings['static'])?$settings['static']:false;
 
 		$this->reflectionType = get_class($this);
 	}
@@ -220,7 +226,7 @@ class ReflectionMethodMagic extends ReflectionMethod
 	 */
 	public function isStatic()
 	{
-		return FALSE;
+		return $this->static;
 	}
 
 

--- a/tests/Reflections/ReflectionBaseTest.php
+++ b/tests/Reflections/ReflectionBaseTest.php
@@ -71,7 +71,7 @@ class ReflectionBaseTest extends PHPUnit_Framework_TestCase
 
 	public function testGetEndLine()
 	{
-		$this->assertSame(41, $this->reflectionClass->getEndLine());
+		$this->assertSame(43, $this->reflectionClass->getEndLine());
 	}
 
 

--- a/tests/Reflections/ReflectionMethodMagicTest.php
+++ b/tests/Reflections/ReflectionMethodMagicTest.php
@@ -205,14 +205,14 @@ class ReflectionMethodMagicTest extends PHPUnit_Framework_TestCase
 
 	public function testStaticMethodReturnType()
 	{
-		$method = $this->reflectionClass->getMagicMethods()['doAnStaticOperation'];
+		$method = $this->reflectionClass->getMagicMethods()['doAStaticOperation'];
 		$this->assertSame('string', current($method->getAnnotation('return')));
 	}
 
 
 	public function testVoidStaticMethod()
 	{
-		$method = $this->reflectionClass->getMagicMethods()['doAnVoidStaticOperation'];
+		$method = $this->reflectionClass->getMagicMethods()['doAVoidStaticOperation'];
 		$this->assertEmpty(current($method->getAnnotation('return')));
 	}
 

--- a/tests/Reflections/ReflectionMethodMagicTest.php
+++ b/tests/Reflections/ReflectionMethodMagicTest.php
@@ -196,6 +196,27 @@ class ReflectionMethodMagicTest extends PHPUnit_Framework_TestCase
 	}
 
 
+	public function testStaticMethod()
+	{
+		$method = $this->reflectionClass->getMagicMethods()['doAnStaticOperation'];
+		$this->assertTrue($method->isStatic());
+	}
+
+
+	public function testStaticMethodReturnType()
+	{
+		$method = $this->reflectionClass->getMagicMethods()['doAnStaticOperation'];
+		$this->assertSame('string', current($method->getAnnotation('return')));
+	}
+
+
+	public function testVoidStaticMethod()
+	{
+		$method = $this->reflectionClass->getMagicMethods()['doAnVoidStaticOperation'];
+		$this->assertEmpty(current($method->getAnnotation('return')));
+	}
+
+
 	/**
 	 * @return Mockery\MockInterface
 	 */

--- a/tests/Reflections/ReflectionMethodMagicTest.php
+++ b/tests/Reflections/ReflectionMethodMagicTest.php
@@ -198,7 +198,7 @@ class ReflectionMethodMagicTest extends PHPUnit_Framework_TestCase
 
 	public function testStaticMethod()
 	{
-		$method = $this->reflectionClass->getMagicMethods()['doAnStaticOperation'];
+		$method = $this->reflectionClass->getMagicMethods()['doAStaticOperation'];
 		$this->assertTrue($method->isStatic());
 	}
 

--- a/tests/Reflections/ReflectionMethodSource/ReflectionMethod.php
+++ b/tests/Reflections/ReflectionMethodSource/ReflectionMethod.php
@@ -15,6 +15,8 @@ namespace Project;
  * @property-read int $skillCounter
  * @method string getName() This is some short description.
  * @method string doAnOperation(\stdClass $data, $type) This also some description.
+ * @method static string doAnStaticOperation(\stdClass $data, $type) This also some description.
+ * @method static doAnVoidStaticOperation(\stdClass $data, $type) This also some description.
  *
  * @package Some_Package
  */

--- a/tests/Reflections/ReflectionMethodSource/ReflectionMethod.php
+++ b/tests/Reflections/ReflectionMethodSource/ReflectionMethod.php
@@ -15,8 +15,8 @@ namespace Project;
  * @property-read int $skillCounter
  * @method string getName() This is some short description.
  * @method string doAnOperation(\stdClass $data, $type) This also some description.
- * @method static string doAnStaticOperation(\stdClass $data, $type) This also some description.
- * @method static doAnVoidStaticOperation(\stdClass $data, $type) This also some description.
+ * @method static string doAStaticOperation(\stdClass $data, $type) This also some description.
+ * @method static doAVoidStaticOperation(\stdClass $data, $type) This also some description.
  *
  * @package Some_Package
  */


### PR DESCRIPTION
Added support for static magic methods and correct type hinting:

/**
 * @method myMethod(MyClass $name, MyClass $slug)
 * @method static myStaticMethod(MyClass $name, MyClass $slug)
 * @method MyClass myMethodWithReturn(MyClass $name, MyClass $slug)
 * @method static MyClass myStaticMethodWithReturn(MyClass $name, MyClass $slug)
 */
class MyMagicClass {}