### PR TITLE
Remove spaces from apigen.services.neon that were causing a Nette\Neon\Exception exception

### DIFF
--- a/src/DI/apigen.services.neon
+++ b/src/DI/apigen.services.neon
@@ -8,9 +8,9 @@ services:
 	- ApiGen\Configuration\ConfigurationOptionsResolver
 	- ApiGen\Configuration\OptionsResolverFactory
 	-
-	 	implement: ApiGen\Configuration\Theme\ThemeConfigFactory
-	 	parameters: [filePath]
-	 	arguments: [%filePath%]
+		implement: ApiGen\Configuration\Theme\ThemeConfigFactory
+		parameters: [filePath]
+		arguments: [%filePath%]
 	- ApiGen\Configuration\Theme\ThemeConfigOptionsResolver
 
 	# console


### PR DESCRIPTION
I noticed this error when requiring ApiGen as a Composer dependency in my project. The downloaded phar file seems to work well, but when running `./vendor/bin/apigen generate`, I received an error about tabs and spaces being mixed in a neon file.

I cloned ApiGen/ApiGen and ran `phpunit`, receiving the same error message (see below). Removing the spaces from the lines in `src/DI/apigen.services.neon` (see diff) fixes the problem.

```
$ phpunit
PHP Fatal error:  Uncaught exception 'Nette\Neon\Exception' with message 'Either tabs or spaces may be used as indenting chars, but not both. on line 11, column 4.' in /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/neon/src/Neon/Decoder.php:306
Stack trace:
#0 /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/neon/src/Neon/Decoder.php(194): Nette\Neon\Decoder->error('Either tabs or ...')
#1 /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/neon/src/Neon/Decoder.php(203): Nette\Neon\Decoder->parse(1)
#2 /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/neon/src/Neon/Decoder.php(89): Nette\Neon\Decoder->parse(0)
#3 /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/neon/src/Neon/Neon.php(44): Nette\Neon\Decoder->decode('services:\n\t# co...')
#4 /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/di/src/DI/Config/Adapters/NeonAdapter.php(33): Nette\Neon\Neon::decode('services:\n\t# co...')
#5 /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/di/src/DI/C in /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/neon/src/Neon/Decoder.php on line 306

Fatal error: Uncaught exception 'Nette\Neon\Exception' with message 'Either tabs or spaces may be used as indenting chars, but not both. on line 11, column 4.' in /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/neon/src/Neon/Decoder.php on line 306

Nette\Neon\Exception: Either tabs or spaces may be used as indenting chars, but not both. on line 11, column 4. in /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/neon/src/Neon/Decoder.php on line 306

Call Stack:
    0.0023     315192   1. {main}() /Users/bramsey/bin/phpunit:0
    0.0212     758608   2. PHPUnit_TextUI_Command::main() /Users/bramsey/bin/phpunit:620
    0.0213     759232   3. PHPUnit_TextUI_Command->run() phar:///Users/bramsey/bin/phpunit/phpunit/TextUI/Command.php:103
    0.0213     761808   4. PHPUnit_TextUI_Command->handleArguments() phar:///Users/bramsey/bin/phpunit/phpunit/TextUI/Command.php:113
    0.0258    1390032   5. PHPUnit_Util_Configuration->getTestSuiteConfiguration() phar:///Users/bramsey/bin/phpunit/phpunit/TextUI/Command.php:653
    0.0258    1391296   6. PHPUnit_Util_Configuration->getTestSuite() phar:///Users/bramsey/bin/phpunit/phpunit/Util/Configuration.php:802
    0.0357    1620488   7. PHPUnit_Framework_TestSuite->addTestFiles() phar:///Users/bramsey/bin/phpunit/phpunit/Util/Configuration.php:889
    0.0432    2799816   8. PHPUnit_Framework_TestSuite->addTestFile() phar:///Users/bramsey/bin/phpunit/phpunit/Framework/TestSuite.php:400
    0.0437    3037904   9. PHPUnit_Framework_TestSuite->addTestSuite() phar:///Users/bramsey/bin/phpunit/phpunit/Framework/TestSuite.php:374
    0.0437    3038144  10. PHPUnit_Framework_TestSuite->__construct() phar:///Users/bramsey/bin/phpunit/phpunit/Framework/TestSuite.php:289
    0.0438    3140952  11. PHPUnit_Framework_TestSuite->addTestMethod() phar:///Users/bramsey/bin/phpunit/phpunit/Framework/TestSuite.php:188
    0.0438    3141376  12. PHPUnit_Framework_TestSuite::createTest() phar:///Users/bramsey/bin/phpunit/phpunit/Framework/TestSuite.php:842
    0.0439    3143680  13. ApiGen\Tests\ContainerAwareTestCase->__construct() phar:///Users/bramsey/bin/phpunit/phpunit/Framework/TestSuite.php:458
    0.0440    3148624  14. ApiGen\Tests\ContainerFactory->create() /Users/bramsey/Documents/Projects/ramsey/ApiGen/tests/ContainerAwareTestCase.php:30
    0.0457    3462216  15. Nette\Configurator->createContainer() /Users/bramsey/Documents/Projects/ramsey/ApiGen/tests/ContainerFactory.php:21
    0.0461    3503344  16. Nette\DI\ContainerFactory->create() /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/bootstrap/src/Bootstrap/Configurator.php:182
    0.0461    3503832  17. Nette\DI\ContainerFactory->loadClass() /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/di/src/DI/ContainerFactory.php:57
    0.0465    3506024  18. Nette\DI\ContainerFactory->generateCode() /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/di/src/DI/ContainerFactory.php:135
    0.0513    4315192  19. Nette\DI\Compiler->compile() /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/di/src/DI/ContainerFactory.php:78
    0.0516    4365272  20. Nette\DI\Compiler->processExtensions() /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/di/src/DI/Compiler.php:95
    0.0555    4842136  21. ApiGen\DI\ApiGenExtension->loadConfiguration() /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/di/src/DI/Compiler.php:116
    0.0555    4842216  22. ApiGen\DI\ApiGenExtension->loadServicesFromConfig() /Users/bramsey/Documents/Projects/ramsey/ApiGen/src/DI/ApiGenExtension.php:25
    0.0556    4842512  23. Nette\DI\CompilerExtension->loadFromFile() /Users/bramsey/Documents/Projects/ramsey/ApiGen/src/DI/ApiGenExtension.php:43
    0.0556    4842640  24. Nette\DI\Config\Loader->load() /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/di/src/DI/CompilerExtension.php:68
    0.0556    4843232  25. Nette\DI\Config\Adapters\NeonAdapter->load() /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/di/src/DI/Config/Loader.php:47
    0.0556    4847432  26. Nette\Neon\Neon::decode() /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/di/src/DI/Config/Adapters/NeonAdapter.php:33
    0.0556    4847576  27. Nette\Neon\Decoder->decode() /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/neon/src/Neon/Neon.php:44
    0.0561    5191064  28. Nette\Neon\Decoder->parse() /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/neon/src/Neon/Decoder.php:89
    0.0561    5191528  29. Nette\Neon\Decoder->parse() /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/neon/src/Neon/Decoder.php:203
    0.0562    5194176  30. Nette\Neon\Decoder->error() /Users/bramsey/Documents/Projects/ramsey/ApiGen/vendor/nette/neon/src/Neon/Decoder.php:194

```