### PR TITLE
Exclude/source over skipDocPath

### DIFF
--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -128,9 +128,6 @@ class GenerateCommand extends Command
 				'Elements with this name prefix will be first in tree.')
 			->addOption(CO::INTERNAL, NULL, InputOption::VALUE_NONE, 'Include elements marked as @internal.')
 			->addOption(CO::PHP, NULL, InputOption::VALUE_NONE, 'Generate documentation for PHP internal classes.')
-			->addOption(CO::SKIP_DOC_PATH, NULL, InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
-				'Files matching this mask will be included in class tree,'
-				. ' but will not create a link to their documentation.')
 			->addOption(CO::NO_SOURCE_CODE, NULL, InputOption::VALUE_NONE,
 				'Do not generate highlighted source code for elements.')
 			->addOption(CO::TEMPLATE_THEME, NULL, InputOption::VALUE_REQUIRED, 'ApiGen template theme name.', 'default')

--- a/src/Configuration/ConfigurationOptions.php
+++ b/src/Configuration/ConfigurationOptions.php
@@ -30,7 +30,6 @@ class ConfigurationOptions
 	const MAIN = 'main';
 	const INTERNAL = 'internal';
 	const PHP = 'php';
-	const SKIP_DOC_PATH = 'skipDocPath';
 	const SOURCE = 'source';
 	const NO_SOURCE_CODE = 'noSourceCode';
 	const TEMPLATE = 'template';

--- a/src/Configuration/ConfigurationOptionsResolver.php
+++ b/src/Configuration/ConfigurationOptionsResolver.php
@@ -49,7 +49,6 @@ class ConfigurationOptionsResolver
 		CO::MAIN => '',
 		CO::INTERNAL => FALSE,
 		CO::PHP => FALSE,
-		CO::SKIP_DOC_PATH => [],
 		CO::SOURCE => [],
 		CO::NO_SOURCE_CODE => FALSE,
 		CO::TEMPLATE => NULL,
@@ -197,12 +196,6 @@ class ConfigurationOptionsResolver
 			},
 			CO::BASE_URL => function (Options $options, $value) {
 				return rtrim($value, '/');
-			},
-			CO::SKIP_DOC_PATH => function (Options $options, $value) {
-				foreach ($value as $key => $source) {
-					$value[$key] = FileSystem::getAbsolutePath($source);
-				}
-				return $value;
 			},
 			CO::SOURCE => function (Options $options, $value) {
 				if ( ! is_array($value)) {

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -774,26 +774,6 @@ class ReflectionClass extends ReflectionElement
 	/**
 	 * @return bool
 	 */
-	public function isDocumented()
-	{
-		if ($this->isDocumented === NULL && parent::isDocumented()) {
-			$fileName = $this->reflection->getFilename();
-			$skipDocPath = $this->configuration->getOption(CO::SKIP_DOC_PATH);
-			foreach ($skipDocPath as $mask) {
-				if (fnmatch($mask, $fileName, FNM_NOESCAPE)) {
-					$this->isDocumented = FALSE;
-					break;
-				}
-			}
-		}
-
-		return $this->isDocumented;
-	}
-
-
-	/**
-	 * @return bool
-	 */
 	public function isVisibilityLevelPublic()
 	{
 		return $this->getVisibilityLevel() & Visibility::IS_PUBLIC;

--- a/src/Reflection/ReflectionConstant.php
+++ b/src/Reflection/ReflectionConstant.php
@@ -9,7 +9,6 @@
 
 namespace ApiGen\Reflection;
 
-use ApiGen\Configuration\ConfigurationOptions as CO;
 use TokenReflection;
 
 
@@ -113,25 +112,6 @@ class ReflectionConstant extends ReflectionElement
 		}
 
 		return TRUE;
-	}
-
-
-	/**
-	 * @return bool
-	 */
-	public function isDocumented()
-	{
-		if ($this->isDocumented === NULL && parent::isDocumented() && $this->reflection->getDeclaringClassName() === NULL) {
-			$fileName = $this->reflection->getFilename();
-			$skipDocPath = $this->configuration->getOption(CO::SKIP_DOC_PATH);
-			foreach ($skipDocPath as $mask) {
-				if (fnmatch($mask, $fileName, FNM_NOESCAPE)) {
-					$this->isDocumented = FALSE;
-					break;
-				}
-			}
-		}
-		return $this->isDocumented;
 	}
 
 }

--- a/src/Reflection/ReflectionFunction.php
+++ b/src/Reflection/ReflectionFunction.php
@@ -9,7 +9,6 @@
 
 namespace ApiGen\Reflection;
 
-use ApiGen\Configuration\ConfigurationOptions as CO;
 use TokenReflection;
 
 
@@ -26,25 +25,6 @@ class ReflectionFunction extends ReflectionFunctionBase
 		}
 
 		return TRUE;
-	}
-
-
-	/**
-	 * @return bool
-	 */
-	public function isDocumented()
-	{
-		if ($this->isDocumented === NULL && parent::isDocumented()) {
-			$fileName = $this->reflection->getFilename();
-			$skipDocPath = $this->configuration->getOption(CO::SKIP_DOC_PATH);
-			foreach ($skipDocPath as $mask) {
-				if (fnmatch($mask, $fileName, FNM_NOESCAPE)) {
-					$this->isDocumented = FALSE;
-					break;
-				}
-			}
-		}
-		return $this->isDocumented;
 	}
 
 }

--- a/tests/Parser/Broker/BackendTest.php
+++ b/tests/Parser/Broker/BackendTest.php
@@ -116,7 +116,6 @@ class BackendTest extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn([]);
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(1);
 		return $configurationMock;
 	}

--- a/tests/Reflections/ReflectionBaseTest.php
+++ b/tests/Reflections/ReflectionBaseTest.php
@@ -102,7 +102,6 @@ class ReflectionBaseTest extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn(['*SomeConstant.php*']);
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(256);
 		return $configurationMock;
 	}

--- a/tests/Reflections/ReflectionClass/TestCase.php
+++ b/tests/Reflections/ReflectionClass/TestCase.php
@@ -78,7 +78,6 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn(['*SomeConstant.php*']);
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(256 | 512);
 		return $configurationMock;
 	}

--- a/tests/Reflections/ReflectionConstantTest.php
+++ b/tests/Reflections/ReflectionConstantTest.php
@@ -109,7 +109,7 @@ class ReflectionConstantTest extends PHPUnit_Framework_TestCase
 
 	public function testIsDocumented()
 	{
-		$this->assertFalse($this->constantReflection->isDocumented());
+		$this->assertTrue($this->constantReflection->isDocumented());
 		$this->assertTrue($this->constantReflectionInClass->isDocumented());
 	}
 
@@ -138,7 +138,6 @@ class ReflectionConstantTest extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn(['*SomeConstant.php*']);
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(1);
 		return $configurationMock;
 	}

--- a/tests/Reflections/ReflectionElementTest.php
+++ b/tests/Reflections/ReflectionElementTest.php
@@ -225,7 +225,6 @@ class ReflectionElementTest extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn(['*SomeConstant.php*']);
 		$configurationMock->shouldReceive('getOption')->with('main')->andReturn('');
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(256);
 		return $configurationMock;

--- a/tests/Reflections/ReflectionExtensionTest.php
+++ b/tests/Reflections/ReflectionExtensionTest.php
@@ -58,7 +58,6 @@ class ReflectionExtensionTest extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(TRUE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn([]);
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(256);
 		return $configurationMock;
 	}

--- a/tests/Reflections/ReflectionFunctionBaseTest.php
+++ b/tests/Reflections/ReflectionFunctionBaseTest.php
@@ -146,7 +146,6 @@ class ReflectionParameterBaseTest extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn([]);
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(256);
 		return $configurationMock;
 	}

--- a/tests/Reflections/ReflectionFunctionTest.php
+++ b/tests/Reflections/ReflectionFunctionTest.php
@@ -61,7 +61,6 @@ class ReflectionFunctionTest extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn([]);
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(256);
 		return $configurationMock;
 	}

--- a/tests/Reflections/ReflectionMethodMagicTest.php
+++ b/tests/Reflections/ReflectionMethodMagicTest.php
@@ -220,7 +220,6 @@ class ReflectionMethodMagicTest extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn(['*SomeConstant.php*']);
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(256);
 		return $configurationMock;
 	}

--- a/tests/Reflections/ReflectionMethodTest.php
+++ b/tests/Reflections/ReflectionMethodTest.php
@@ -171,7 +171,6 @@ class ReflectionMethodTest extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn(['*SomeConstant.php*']);
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(256);
 		return $configurationMock;
 	}

--- a/tests/Reflections/ReflectionParameterMagicTest.php
+++ b/tests/Reflections/ReflectionParameterMagicTest.php
@@ -216,7 +216,6 @@ class ReflectionParameterMagicTest extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn(['*SomeConstant.php*']);
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(256);
 		return $configurationMock;
 	}

--- a/tests/Reflections/ReflectionParameterTest.php
+++ b/tests/Reflections/ReflectionParameterTest.php
@@ -176,7 +176,6 @@ class ReflectionParameterTest extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn(['*SomeConstant.php*']);
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(256);
 		return $configurationMock;
 	}

--- a/tests/Reflections/ReflectionPropertyMagicTest.php
+++ b/tests/Reflections/ReflectionPropertyMagicTest.php
@@ -164,7 +164,6 @@ class ReflectionPropertyMagicTest extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn(['*SomeConstant.php*']);
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(256);
 		return $configurationMock;
 	}

--- a/tests/Reflections/ReflectionPropertyTest.php
+++ b/tests/Reflections/ReflectionPropertyTest.php
@@ -163,7 +163,6 @@ class ReflectionPropertyTest extends PHPUnit_Framework_TestCase
 		$configurationMock->shouldReceive('getOption')->with('php')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('deprecated')->andReturn(FALSE);
 		$configurationMock->shouldReceive('getOption')->with('internal')->andReturn(FALSE);
-		$configurationMock->shouldReceive('getOption')->with('skipDocPath')->andReturn(['*SomeConstant.php*']);
 		$configurationMock->shouldReceive('getOption')->with(CO::VISIBILITY_LEVELS)->andReturn(256);
 		return $configurationMock;
 	}

--- a/tests/Scanner/ScannerExcludeTest.php
+++ b/tests/Scanner/ScannerExcludeTest.php
@@ -42,4 +42,12 @@ class ScannerExcludeTest extends PHPUnit_Framework_TestCase
 		$this->assertCount(1, $this->scanner->scan($source, ['src/Core/smarty_cache']));
 	}
 
+
+	public function testExcludeFile()
+	{
+		$source = __DIR__ . '/ScannerExcludeSource/src';
+		$this->assertCount(0, $this->scanner->scan($source, ['ShouldBeExcluded.php']));
+		$this->assertCount(0, $this->scanner->scan($source, ['*ShouldBeExcluded*']));
+	}
+
 }


### PR DESCRIPTION
`skipDocPath` option allows generation of doc, where only method names are displayed with no more details.

In case of skipping generation of whole lib (e.g. nette\nette package only for Nette\Object class), it's recommended including Nette\Object.php in sources. In this way, all methods with full descriptions will be allowed.

For excluding of multiple dirs/files `--exclude` option should be used.
