### PR TITLE
Composer: fix version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 
 		"kukulich/fshl": "~2.1",
 		"michelf/php-markdown": "~1.4",
-		"symfony/options-resolver": "~2.6.1",
+		"symfony/options-resolver": "^2.6.1",
 		"symfony/console": "~2.6",
 		"symfony/yaml": "~2.6",
 		"herrera-io/phar-update": "~2.0",


### PR DESCRIPTION
Use caret instead of tilde to allow any version of Symfony component up
to 3.0 (instead of limiting symfony/options-resolver to 2.7).

https://getcomposer.org/doc/01-basic-usage.md#next-significant-release-tilde-and-caret-operators-