### PR TITLE
README - remove Bad Apostrophe

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ php vendor/bin/apigen generate -s src -d ../my/project-api
 
 ## Options
 
-To see all available options with it's description and default values, just run:
+To see all available options with its description and default values, just run:
 
 ```sh
 apigen generate --help


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!