### PR TITLE
Pin nette/latte version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"nette/mail": "~2.2",
 		"nette/robot-loader": "~2.2",
 		"nette/safe-stream": "~2.2",
-		"latte/latte": "~2.2",
+		"latte/latte": ">=2.2.0,<2.3.5",
 		"tracy/tracy": "~2.2",
 
 		"kukulich/fshl": "~2.1",


### PR DESCRIPTION
The `trigger_error` calls added in https://github.com/nette/latte/commit/a27abc380c18aa1df44113d3c13f143b54cbf7b7 break builds for every project.

Pinning version until we can find the solution.