### PR TITLE
Parser exceptions

### DIFF
--- a/src/Console/Command/GenerateCommand.php
+++ b/src/Console/Command/GenerateCommand.php
@@ -268,12 +268,18 @@ class GenerateCommand extends AbstractCommand
     {
         /** @var FileProcessingException[] $errors */
         foreach ($errors as $error) {
-            /** @var \Exception[] $reasons */
-            $reasons = $error->getReasons();
-            if (count($reasons) && isset($reasons[0])) {
-                $this->io->writeln(
-                    sprintf('<error>Parse error: "%s"</error>', $reasons[0]->getMessage())
-                );
+            $output = null;
+            if ($this->configuration->getOption('debug')) {
+                $output = $error->getDetail();
+            } else {
+                /** @var \Exception[] $reasons */
+                $reasons = $error->getReasons();
+                if (isset($reasons[0]) && count($reasons)) {
+                    $output = $reasons[0]->getMessage();
+                }
+            }
+            if ($output) {
+                $this->io->writeln(sprintf('<error>Parse error: "%s"</error>', $output));
             }
         }
     }

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -15,6 +15,7 @@ use ArrayObject;
 use TokenReflection\Broker;
 use TokenReflection\Broker\Backend;
 use TokenReflection\Exception\FileProcessingException;
+use TokenReflection\Exception\ParseException;
 
 class Parser implements ParserInterface
 {
@@ -50,7 +51,8 @@ class Parser implements ParserInterface
         foreach ($files as $file) {
             try {
                 $this->broker->processFile($file->getPathname());
-
+            } catch (ParseException $exception) {
+                $this->errors[] = new FileProcessingException([$exception]);
             } catch (FileProcessingException $exception) {
                 $this->errors[] = $exception;
             }


### PR DESCRIPTION
`ParserExceptions` were not being handled so the `GenerateCommand` would fail.

Also, messages like "Unexpected token found." are not very useful for tracking things down.

Now with `--debug` flag, you will get output such as:

```
Parse error: "There were following reasons for this exception:
Thrown when working with file "tests/_fixture/InterfaceWithSemiReservedMethodName.php" token stream.
The cause of the exception was the T_UNSET token (line 4) in following part of the source code:

 1: <?php
 2: interface InterfaceWithSemiReservedMethodName
 3: {
*4:     public function unset();
 5: }
 6: "
```

Also, the API will continue generating until 100%, rather than halting abruptly.

Refs #652 