### PR TITLE
Trait methods

### DIFF
--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -156,7 +156,30 @@ class ReflectionClass extends ReflectionElement
 					}
 				}
 			}
+
+			if (null !== $this->getParentClassName()) {
+				foreach ($this->getParentClass()->getMethods() as $parentMethod) {
+					if (!array_key_exists($parentMethod->getName(), $this->methods)) {
+						$this->methods[$parentMethod->getName()] = $parentMethod;
+					}
+				}
+			}
+
+			foreach ($this->getOwnInterfaces() as $interface) {
+				foreach ($interface->getMethods(null) as $parentMethod) {
+					if (!array_key_exists($parentMethod->getName(), $this->methods)) {
+						$this->methods[$parentMethod->getName()] = $parentMethod;
+					}
+				}
+			}
+
+			$this->methods = array_filter($this->methods, function(ReflectionMethod $method) {
+				$classVisibilityLevel = $this->getVisibilityLevel();
+				$methodVisibilityLevel = $method->configuration->getOption(CO::VISIBILITY_LEVELS);
+				return $classVisibilityLevel === $methodVisibilityLevel;
+			});
 		}
+
 		return $this->methods;
 	}
 

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -151,7 +151,7 @@ class ReflectionClass extends ReflectionElement
 					continue;
 				}
 				foreach ($trait->getOwnMethods() as $method) {
-					if (array_key_exists($method->getName(), $this->methods)) {
+					if (isset($this->methods[$method->getName()])) {
 						continue;
 					}
 					if (! $this->isDocumented() || $method->isDocumented()) {
@@ -162,7 +162,7 @@ class ReflectionClass extends ReflectionElement
 
 			if (null !== $this->getParentClassName()) {
 				foreach ($this->getParentClass()->getMethods() as $parentMethod) {
-					if (!array_key_exists($parentMethod->getName(), $this->methods)) {
+					if (!isset($this->methods[$parentMethod->getName()])) {
 						$this->methods[$parentMethod->getName()] = $parentMethod;
 					}
 				}
@@ -170,7 +170,7 @@ class ReflectionClass extends ReflectionElement
 
 			foreach ($this->getOwnInterfaces() as $interface) {
 				foreach ($interface->getMethods(null) as $parentMethod) {
-					if (!array_key_exists($parentMethod->getName(), $this->methods)) {
+					if (!isset($this->methods[$parentMethod->getName()])) {
 						$this->methods[$parentMethod->getName()] = $parentMethod;
 					}
 				}

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -145,8 +145,12 @@ class ReflectionClass extends ReflectionElement
 	{
 		if ($this->methods === NULL) {
 			$this->methods = $this->getOwnMethods();
-
-			foreach ($this->reflection->getMethods($this->getVisibilityLevel()) as $method) {
+			try {
+				$reflectionMethods = $this->reflection->getMethods($this->getVisibilityLevel());
+			} catch (\RuntimeException $exception) {
+				return $this->methods;
+			}
+			foreach ($reflectionMethods as $method) {
 				/** @var ReflectionElement|TokenReflection\Php\IReflection $method */
 				if (isset($this->methods[$method->getName()])) {
 					continue;

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -147,6 +147,9 @@ class ReflectionClass extends ReflectionElement
 			$this->methods = $this->getOwnMethods();
 
 			foreach ($this->getOwnTraits() as $trait) {
+				if (!$trait instanceof ReflectionClass) {
+					continue;
+				}
 				foreach ($trait->getOwnMethods() as $method) {
 					if (array_key_exists($method->getName(), $this->methods)) {
 						continue;

--- a/src/Reflection/ReflectionClass.php
+++ b/src/Reflection/ReflectionClass.php
@@ -145,19 +145,15 @@ class ReflectionClass extends ReflectionElement
 	{
 		if ($this->methods === NULL) {
 			$this->methods = $this->getOwnMethods();
-			try {
-				$reflectionMethods = $this->reflection->getMethods($this->getVisibilityLevel());
-			} catch (\RuntimeException $exception) {
-				return $this->methods;
-			}
-			foreach ($reflectionMethods as $method) {
-				/** @var ReflectionElement|TokenReflection\Php\IReflection $method */
-				if (isset($this->methods[$method->getName()])) {
-					continue;
-				}
-				$apiMethod = $this->reflectionFactory->createFromReflection($method);
-				if ( ! $this->isDocumented() || $apiMethod->isDocumented()) {
-					$this->methods[$method->getName()] = $apiMethod;
+
+			foreach ($this->getOwnTraits() as $trait) {
+				foreach ($trait->getOwnMethods() as $method) {
+					if (array_key_exists($method->getName(), $this->methods)) {
+						continue;
+					}
+					if (! $this->isDocumented() || $method->isDocumented()) {
+						$this->methods[$method->getName()] = $method;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fuller implementation of `ReflectionClass::getMethods()` that avoids calling getMethods() on underlying PHP-Token-Reflection library. This works around fatal errors due to trait methods being loaded more than once.

Ideally upstream would merge the outstanding PR but short of maintaining our own fork this seems to be all we can do for now.

Refs #652