### PR TITLE
config.neon - don't scan composer autoloader for presenters

### DIFF
--- a/src/DI/config.neon
+++ b/src/DI/config.neon
@@ -4,3 +4,6 @@ extensions:
 	- ApiGen\EventDispatcher\DI\EventDispatcherExtension
 	- ApiGen\Parser\DI\ParserExtension
 	- ApiGen\Utils\DI\UtilsExtension
+
+application:
+	scanComposer: false


### PR DESCRIPTION
Fixes issue #644.