### PR TITLE
make temp dir user dependent

### DIFF
--- a/bin/apigen
+++ b/bin/apigen
@@ -10,6 +10,9 @@ require __DIR__ . '/bootstrap.php';
 
 // Create temp dir
 $tempDir = sys_get_temp_dir() . '/_apigen';
+if (function_exists("posix_getuid")) {
+	$tempDir .= posix_getuid();
+}
 $fileSystem = new ApiGen\Utils\FileSystem;
 $fileSystem->purgeDir($tempDir);
 


### PR DESCRIPTION
When installed in a shared localtion, it can be use by various users.
Each user need a different cache directory to avoid permission denied error on cleanup.
