### PR TITLE
Stop unit tests writing to stdout

### DIFF
--- a/tests/Console/Helper/ProgressBarTest.php
+++ b/tests/Console/Helper/ProgressBarTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Helper\ProgressBar as SymfonyProgressBar;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\NullOutput;
 
 class ProgressBarTest extends PHPUnit_Framework_TestCase
 {
@@ -28,7 +28,7 @@ class ProgressBarTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $io = new IO(new HelperSet, new LiberalFormatArgvInput, new ConsoleOutput);
+        $io = new IO(new HelperSet, new LiberalFormatArgvInput, new NullOutput);
         $this->progressBar = new ProgressBar($io);
     }
 
@@ -71,7 +71,7 @@ class ProgressBarTest extends PHPUnit_Framework_TestCase
 
         $arrayInput = new ArgvInput([], new InputDefinition([new InputOption('debug')]));
         $arrayInput->setOption('debug', true);
-        $io = new IO(new HelperSet, $arrayInput, new ConsoleOutput);
+        $io = new IO(new HelperSet, $arrayInput, new NullOutput);
         $progressBar = new ProgressBar($io);
 
         $this->assertSame('debug', MethodInvoker::callMethodOnObject($progressBar, 'getBarFormat'));

--- a/tests/Console/IO/IOTest.php
+++ b/tests/Console/IO/IOTest.php
@@ -10,9 +10,9 @@ use RuntimeException;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
 
 class IOTest extends PHPUnit_Framework_TestCase
 {
@@ -41,7 +41,7 @@ class IOTest extends PHPUnit_Framework_TestCase
     {
         $questionHelper = new QuestionHelper;
         $questionHelper->setInputStream($this->getInputStream("Test\n"));
-        $io = new IO(new HelperSet(['question' => $questionHelper]), new LiberalFormatArgvInput, new ConsoleOutput);
+        $io = new IO(new HelperSet(['question' => $questionHelper]), new LiberalFormatArgvInput, new StreamOutput(fopen('php://memory', 'w', false)));
 
         $this->assertFalse($io->ask('Is this true', true));
         $this->setExpectedException(RuntimeException::class);


### PR DESCRIPTION
Before:

```sh-session
$ vendor/bin/phpunit
100 % - Finished!
....Is this true [yes] Is this true [no] ..........................................  63 / 531 ( 11%)
............................................................... 126 / 531 ( 23%)
```

After:

```sh-session
$ vendor/bin/phpunit
...............................................................  63 / 531 ( 11%)
............................................................... 126 / 531 ( 23%)
```