### PR TITLE
fixed config.neon after nette/application was removed in bc3108a15a

### DIFF
--- a/src/DI/config.neon
+++ b/src/DI/config.neon
@@ -4,6 +4,3 @@ extensions:
 	- ApiGen\EventDispatcher\DI\EventDispatcherExtension
 	- ApiGen\Parser\DI\ParserExtension
 	- ApiGen\Utils\DI\UtilsExtension
-
-application:
-	scanComposer: false


### PR DESCRIPTION
Fixed error
> Nette\InvalidStateException: Found section 'application' in configuration, but corresponding extension is missing.