### PR TITLE
services: uses DevNullStorage

### DIFF
--- a/src/DI/services.neon
+++ b/src/DI/services.neon
@@ -66,3 +66,5 @@ services:
 		class: FSHL\Highlighter
 		setup:
 			- setLexer(@FSHL\Lexer\Php)
+
+	cacheStorage: Nette\Caching\Storages\DevNullStorage

--- a/tests/EventDispatcher/config/default.neon
+++ b/tests/EventDispatcher/config/default.neon
@@ -1,6 +1,7 @@
 services:
 	- ApiGen\EventDispatcher\Tests\EventDispatcher\DispatchSource\Subscriber
 	- ApiGen\EventDispatcher\Tests\EventDispatcher\DispatchSource\SomeService
+	cacheStorage: Nette\Caching\Storages\DevNullStorage
 
 extensions:
 	- ApiGen\EventDispatcher\DI\EventDispatcherExtension

--- a/tests/Parser/config/default.neon
+++ b/tests/Parser/config/default.neon
@@ -1,4 +1,5 @@
-#services:
+services:
+	cacheStorage: Nette\Caching\Storages\DevNullStorage
 #	- ApiGen\Parser\Tests\Resolvers\ElementResolver
 
 

--- a/tests/config/default.neon
+++ b/tests/config/default.neon
@@ -4,3 +4,6 @@ extensions:
 	- ApiGen\EventDispatcher\DI\EventDispatcherExtension
 	- ApiGen\Parser\DI\ParserExtension
 	- ApiGen\Utils\DI\UtilsExtension
+
+services:
+	cacheStorage: Nette\Caching\Storages\DevNullStorage


### PR DESCRIPTION
Fixes error `unlink(cache\journal.s3db): Permission denied` under Windows