### PR TITLE
Fix TreeGenerator not making a tree.

### DIFF
--- a/src/Generator/Markups/MarkdownMarkup.php
+++ b/src/Generator/Markups/MarkdownMarkup.php
@@ -51,7 +51,7 @@ class MarkdownMarkup implements Markup
      */
     public function block($text)
     {
-        $pattern = '~<(code|pre)>(.+?)</\1>|```php\s(.+?)\n```~s';
+        $pattern = '~<(code|pre)>(.+?)</\1>|```(?:php)?\s(.+?)\n```~s';
         $highlighted = preg_replace_callback($pattern, [$this, 'highlightCb'], $text);
         $text = $this->markdown->transform($highlighted);
         return trim($text);

--- a/src/Parser/Elements/AutocompleteElements.php
+++ b/src/Parser/Elements/AutocompleteElements.php
@@ -67,6 +67,13 @@ class AutocompleteElements implements AutocompleteElementsInterface
 
         } elseif ($element instanceof ClassReflectionInterface) {
             $this->elements[] = ['c', $element->getPrettyName()];
+
+            foreach ($element->getOwnMethods() as $method) {
+                $this->elements[] = ['m', $method->getPrettyName()];
+            }
+            foreach ($element->getOwnProperties() as $property) {
+                $this->elements[] = ['p', $property->getPrettyName()];
+            }
         }
     }
 

--- a/src/Templating/Filters/UrlFilters.php
+++ b/src/Templating/Filters/UrlFilters.php
@@ -201,7 +201,7 @@ class UrlFilters extends Filters
         // Merge lines
         $long = preg_replace_callback('~(?:<(code|pre)>.+?</\1>)|([^<]*)~s', function ($matches) {
             return ! empty($matches[2])
-                ? preg_replace('~\n(?:\t|[ ])+~', ' ', $matches[2])
+                ? preg_replace('~\n(?:(\s+\n){2,})+~', ' ', $matches[2])
                 : $matches[0];
         }, $long);
 

--- a/tests/Parser/Elements/AutocompleteElementsTest.php
+++ b/tests/Parser/Elements/AutocompleteElementsTest.php
@@ -7,6 +7,8 @@ use ApiGen\Parser\Elements\ElementStorage;
 use ApiGen\Parser\Reflection\ReflectionClass;
 use ApiGen\Parser\Reflection\ReflectionConstant;
 use ApiGen\Parser\Reflection\ReflectionFunction;
+use ApiGen\Parser\Reflection\ReflectionMethod;
+use ApiGen\Parser\Reflection\ReflectionProperty;
 use Mockery;
 use PHPUnit_Framework_TestCase;
 
@@ -24,6 +26,14 @@ class AutocompleteElementsTest extends PHPUnit_Framework_TestCase
         $classReflectionMock = Mockery::mock(ReflectionClass::class);
         $classReflectionMock->shouldReceive('getPrettyName')->andReturn('ClassPrettyName');
         $classReflectionMock->shouldReceive('getOwnConstants')->andReturn([]);
+
+        $methodReflection = Mockery::mock(ReflectionMethod::class);
+        $methodReflection->shouldReceive('getPrettyName')->andReturn('ClassPrettyName::methodName');
+        $classReflectionMock->shouldReceive('getOwnMethods')->andReturn([$methodReflection]);
+
+        $propertyReflection = Mockery::mock(ReflectionProperty::class);
+        $propertyReflection->shouldReceive('getPrettyName')->andReturn('ClassPrettyName::$propertyName');
+        $classReflectionMock->shouldReceive('getOwnProperties')->andReturn([$propertyReflection]);
 
         $constantReflectionMock = Mockery::mock(ReflectionConstant::class);
         $constantReflectionMock->shouldReceive('getPrettyName')->andReturn('ConstantPrettyName');
@@ -47,8 +57,10 @@ class AutocompleteElementsTest extends PHPUnit_Framework_TestCase
         $elements = $this->autocompleteElements->getElements();
         $this->assertSame([
             ['c', 'ClassPrettyName'],
+            ['p', 'ClassPrettyName::$propertyName'],
+            ['m', 'ClassPrettyName::methodName'],
             ['co', 'ConstantPrettyName'],
-            ['f', 'FunctionPrettyName']
+            ['f', 'FunctionPrettyName'],
         ], $elements);
     }
 }


### PR DESCRIPTION
Previously the TreeGenerator created a flat list. This made for a very boring 'tree' as there was only one level to it. These changes build on those in #707, and updates the test to cover the defect.

Fixes #569