### PR TITLE
Fixed unnecessary line break cuts

### DIFF
--- a/src/Templating/Filters/UrlFilters.php
+++ b/src/Templating/Filters/UrlFilters.php
@@ -201,7 +201,7 @@ class UrlFilters extends Filters
         // Merge lines
         $long = preg_replace_callback('~(?:<(code|pre)>.+?</\1>)|([^<]*)~s', function ($matches) {
             return ! empty($matches[2])
-                ? preg_replace('~\n(?:\t|[ ])+~', ' ', $matches[2])
+                ? preg_replace('~\n(?:(\s+\n){2,})+~', ' ', $matches[2])
                 : $matches[0];
         }, $long);
 


### PR DESCRIPTION
phpDoc:

```
/** 
 * ```php
 * public function isCacheable(Request $request)
 * {
 *      if (!parent::isCacheable($request)) {
 *          return false;
 *      }
 *      return ...
 * }
 * ```
 */
```

Before
![image](https://cloud.githubusercontent.com/assets/683358/16764435/e242f5ae-4879-11e6-9d58-f5b7fa9c73d4.png)

After
![image](https://cloud.githubusercontent.com/assets/683358/16764454/fa2af838-4879-11e6-8868-a09828235b55.png)
