### PR TITLE
Changed php-token-reflection dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require": {
 		"php": ">=5.5",
-		"andrewsville/php-token-reflection": "^1.4",
+		"popsul/php-token-reflection": "^1.5",
 		"apigen/theme-bootstrap": "1.1.*",
 		"apigen/theme-default": "1.0.*",
 		"herrera-io/phar-update": "~2.0",


### PR DESCRIPTION
Hello!

I created a fork of php-token-reflection (https://github.com/POPSuL/PHP-Token-Reflection) which I'm going to support as I can.

At this moment I collected all changes from that repository https://github.com/kornrunner/PHP-Token-Reflection (many fixes for PHP 5.6) and I added basic support for constants expressions (like const A = 4 / 2) and array constants (like const B = [1, 2, 3]).

Before:

ApiGen returns error like "Value definition is empty" for code like this:

```php
class A {

    const B = [1, 2, 3];
}
```

After:
Everything works perfectly! :+1: 