### PR TITLE
Remove incompatible dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
 		"squizlabs/php_codesniffer": "~2.0",
 		"phpunit/phpunit": "~4.0"
 	},
+	"conflict": {
+		"nette/utils": "~2.4.0"
+	},
 	"autoload": {
 		"psr-4": {
 			"ApiGen\\": "src"


### PR DESCRIPTION
ApiGen currently doesn't play well with nette-2.4:

> Nette\DI\ServiceDefinition::getImplementType() is deprecated

This prevents generating documentation or running the test suite.

This commit would remove the offending dependency. Tests are
failing, but I couldn't see if this is a regressen, as before
the tests were failing because of said incompatibility.

With this commit the tests are at least running again and the
documentation can be generated as well.

See also: ApiGen/ApiGen#724 Kdyby/Events#99