### PR TITLE
Fixed deprecated usage of Compiler::compile()

### DIFF
--- a/tests/DI/ApiGenExtensionTest.php
+++ b/tests/DI/ApiGenExtensionTest.php
@@ -113,10 +113,11 @@ class ApiGenExtensionTest extends PHPUnit_Framework_TestCase
     private function getCompiler()
     {
         $compiler = new Compiler(new ContainerBuilder);
-        $compiler->compile(['parameters' => [
+        $compiler->addConfig(['parameters' => [
             'rootDir' => __DIR__ . '/..',
             'tempDir' => __DIR__ . '/../temp'
-        ]], null, null);
+        ]]);
+        $compiler->compile();
         return $compiler;
     }
 }


### PR DESCRIPTION
> Nette\DI\Compiler::compile arguments are deprecated, use Compiler::addConfig() and Compiler::setClassName().