### PR TITLE
Add support for v3 version of Symfony Components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
 		"nette/di": "^2.3",
 		"nette/neon": "^2.3",
 		"nette/reflection": "^2.3",
-		"symfony/console": "^2.7",
-		"symfony/event-dispatcher": "^2.7",
-		"symfony/options-resolver": "^2.7",
-		"symfony/yaml": "^2.7",
+		"symfony/console": "^2.7|~3.0",
+		"symfony/event-dispatcher": "^2.7|~3.0",
+		"symfony/options-resolver": "^2.7|~3.0",
+		"symfony/yaml": "^2.7|~3.0",
 		"tracy/tracy": "^2.3"
 	},
 	"require-dev": {

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -24,6 +24,10 @@ class ApplicationTest extends PHPUnit_Framework_TestCase
      */
     private $application;
 
+    /**
+     * @var string
+     */
+    private $symfonyVersion = '2';
 
     protected function setUp()
     {
@@ -31,13 +35,22 @@ class ApplicationTest extends PHPUnit_Framework_TestCase
         $defaultInputDefinitionFactoryMock = Mockery::mock(DefaultInputDefinitionFactoryInterface::class);
         $defaultInputDefinitionFactoryMock->shouldReceive('create')->andReturn(new InputDefinition);
         $this->application = new Application(new ApiGen, new MemoryLimit, $ioMock, $defaultInputDefinitionFactoryMock);
+        $this->symfonyVersion = (method_exists($this->application, 'asText')
+            ? '2'
+            : '3');
     }
 
 
     public function testGetLongVersion()
     {
+        $longVersion = '<info>ApiGen</info> version <comment>' . ApiGen::VERSION . '</comment>';
+
+        if ($this->symfonyVersion > 2) {
+            $longVersion = 'ApiGen <info>' . ApiGen::VERSION . '</info>';
+        }
+
         $this->assertSame(
-            'ApiGen <info>' . ApiGen::VERSION . '</info>',
+            $longVersion,
             $this->application->getLongVersion()
         );
     }

--- a/tests/Console/ApplicationTest.php
+++ b/tests/Console/ApplicationTest.php
@@ -37,7 +37,7 @@ class ApplicationTest extends PHPUnit_Framework_TestCase
     public function testGetLongVersion()
     {
         $this->assertSame(
-            '<info>ApiGen</info> version <comment>' . ApiGen::VERSION . '</comment>',
+            'ApiGen <info>' . ApiGen::VERSION . '</info>',
             $this->application->getLongVersion()
         );
     }


### PR DESCRIPTION
Add support for v3 version of Symfony Components. Update the test so it can be run with v2 and v3 version of `symfony/console`