### PR TITLE
herrera-io/phar-update is no longer supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"popsul/php-token-reflection": "^1.5",
 		"apigen/theme-bootstrap": "1.1.*",
 		"apigen/theme-default": "1.0.*",
-		"herrera-io/phar-update": "~2.0",
+		"deployer/phar-update": "~2.0",
 		"kukulich/fshl": "~2.1",
 		"latte/latte": "^2.3.6",
 		"michelf/php-markdown": "~1.4",

--- a/src/Console/Command/SelfUpdateCommand.php
+++ b/src/Console/Command/SelfUpdateCommand.php
@@ -10,8 +10,8 @@
 namespace ApiGen\Console\Command;
 
 use Exception;
-use Herrera\Phar\Update\Manager;
-use Herrera\Phar\Update\Manifest;
+use Deployer\Component\PharUpdate\Manager;
+use Deployer\Component\PharUpdate\Manifest;
 use Symfony\Component\Console\Command\Command as BaseCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;


### PR DESCRIPTION
https://packagist.org/packages/herrera-io/phar-update
> This package is abandoned and no longer maintained. No replacement package was suggested.

[deployer/phar-update](https://github.com/deployphp/phar-update) seems to be actively supported.