### PR TITLE
drop description hiding + main option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ To add another configuration, add `apigen.neon` to your root project.
 You can setup all these options:
 
 ```yaml
-main: ApiGen
 visibilityLevels: [public, protected] # array
 annotationGroups: [todo, deprecated] # array
 title: "ApiGen Docs"

--- a/packages/ThemeDefault/src/@elementlist.latte
+++ b/packages/ThemeDefault/src/@elementlist.latte
@@ -1,7 +1,7 @@
 {define elements}
 <tr n:foreach="$elements as $element">
 	<td class="name"><a href="{$element|elementUrl}" n:class="$element->deprecated ? deprecated">{if $namespace}{$element->shortName}{else}{$element->name}{/if}</a></td>
-	<td>{$element|longDescription|noescape}</td>
+	<td>{$element|description|noescape}</td>
 </tr>
 {/define}
 

--- a/packages/ThemeDefault/src/@elementlist.latte
+++ b/packages/ThemeDefault/src/@elementlist.latte
@@ -1,7 +1,7 @@
 {define elements}
 <tr n:foreach="$elements as $element">
 	<td class="name"><a href="{$element|elementUrl}" n:class="$element->deprecated ? deprecated">{if $namespace}{$element->shortName}{else}{$element->name}{/if}</a></td>
-	<td>{$element|shortDescription|noescape}</td>
+	<td>{$element|longDescription|noescape}</td>
 </tr>
 {/define}
 

--- a/packages/ThemeDefault/src/@layout.latte
+++ b/packages/ThemeDefault/src/@layout.latte
@@ -33,7 +33,7 @@
 				{foreach $groups as $group}
 				{continueIf $group === 'PHP'}
 				{var $nextLevel = substr_count($iterator->nextValue, '\\') > substr_count($group, '\\')}
-				<li n:class="$actualGroup === $group || 0 === strpos($actualGroup, $group . '\\') ? active, $config->main && 0 === strpos($group, $config->main) ? main">
+				<li n:class="$actualGroup === $group || 0 === strpos($actualGroup, $group . '\\') ? active">
 					<a href="{if $groupBy === 'package'}{$group|packageUrl}{else}{$group|namespaceUrl}{/if}">
 						{$group|subgroupName}<span n:tag-if="$nextLevel"></span>
 					</a>

--- a/packages/ThemeDefault/src/class.latte
+++ b/packages/ThemeDefault/src/class.latte
@@ -6,9 +6,9 @@
 {block content}
 <div id="content" class="class">
 	<h1 n:class="$class->deprecated ? deprecated">{if $class->interface}Interface{elseif $class->trait}Trait{else}Class{/if} {$class->shortName}</h1>
-	{var $longDescription = ($class|longDescription)}
-	<div class="description" n:if="$longDescription">
-	{$class|longDescription|noescape}
+	{var $classDescription = ($class|description)}
+	<div class="description" n:if="$classDescription">
+		{$classDescription|noescape}
 	</div>
 
 	<dl class="tree" n:if="$class->parentClass || $class->ownInterfaces || $class->ownTraits">
@@ -118,7 +118,7 @@
 		){/block}</code>
 
 		<div class="description detailed">
-			{$method|longDescription|noescape}
+			{$method|description|noescape}
 
 			{if !$class->deprecated && $method->deprecated}
 				<h4>Deprecated</h4>
@@ -138,7 +138,7 @@
 				<div class="list"><dl>
 				{foreach $method->parameters as $parameter}
 					<dt><var>${$parameter->name}</var>{if $parameter->unlimited},…{/if}</dt>
-					<dd>{$parameter->description|description:$method|noescape}</dd>
+					<dd>{$parameter->description|annotationDescription:$method|noescape}</dd>
 				{/foreach}
 				</dl></div>
 			{/if}
@@ -257,7 +257,7 @@
 			</code>
 
 			<div class="description detailed">
-				{$constant|longDescription|noescape}
+				{$constant|description|noescape}
 
                 {var $filteredAnnotations = ($class->annotations|annotationFilter: ['var'])}
 				{foreach $filteredAnnotations as $annotation => $descriptions}
@@ -310,7 +310,7 @@
 			{/if}
 
 			<div class="description detailed">
-				{$property|longDescription|noescape}
+				{$property|description|noescape}
 
                 {var $filteredAnnotations = ($class->annotations|annotationFilter: ['var'])}
 				{foreach $filteredAnnotations as $annotation => $descriptions}

--- a/packages/ThemeDefault/src/class.latte
+++ b/packages/ThemeDefault/src/class.latte
@@ -117,13 +117,7 @@
 			{/foreach}
 		){/block}</code>
 
-		{if $config->template['options']['elementDetailsCollapsed']}
-		<div class="description short">
-			{$method|shortDescription:true|noescape}
-		</div>
-		{/if}
-
-		<div n:class="description, detailed, $config->template['options']['elementDetailsCollapsed'] ? hidden">
+		<div class="description detailed">
 			{$method|longDescription|noescape}
 
 			{if !$class->deprecated && $method->deprecated}
@@ -262,11 +256,7 @@
 			{/if}
 			</code>
 
-			<div n:if="$config->template['options']['elementDetailsCollapsed']" class="description short">
-				{$constant|shortDescription:true|noescape}
-			</div>
-
-			<div n:class="description, detailed, $config->template['options']['elementDetailsCollapsed'] ? hidden">
+			<div class="description detailed">
 				{$constant|longDescription|noescape}
 
                 {var $filteredAnnotations = ($class->annotations|annotationFilter: ['var'])}
@@ -319,11 +309,7 @@
 				<a href="{$property|sourceUrl}" title="Go to source code"><var>${$property->name}</var></a>
 			{/if}
 
-			<div n:if="$config->template['options']['elementDetailsCollapsed']" class="description short">
-				{$property|shortDescription:true|noescape}
-			</div>
-
-			<div n:class="description, detailed, $config->template['options']['elementDetailsCollapsed'] ? hidden">
+			<div class="description detailed">
 				{$property|longDescription|noescape}
 
                 {var $filteredAnnotations = ($class->annotations|annotationFilter: ['var'])}

--- a/packages/ThemeDefault/src/constant.latte
+++ b/packages/ThemeDefault/src/constant.latte
@@ -7,9 +7,9 @@
 <div id="content" class="constant">
 	<h1 n:class="$constant->deprecated ? deprecated">Constant {$constant->shortName}</h1>
 
-	{var $longDescripiton = ($constant|longDescription)}
-	<div n:if="$longDescripiton" class="description">
-		{$longDescripiton|noescape}
+	{var $constantDescription = ($constant|description)}
+	<div n:if="$constantDescription" class="description">
+		{$constantDescription|noescape}
 	</div>
 
 	<div class="info">

--- a/packages/ThemeDefault/src/function.latte
+++ b/packages/ThemeDefault/src/function.latte
@@ -7,9 +7,9 @@
 <div id="content" class="function">
 	<h1 n:class="$function->deprecated ? deprecated">Function {$function->shortName}</h1>
 
-	{var $description = ($function|description)}
-	<div class="description" n:if="$description">
-		{$function|description|noescape}
+	{var $functionDescription = ($function|description)}
+	<div class="description" n:if="$functionDescription">
+		{$functionDescription|noescape}
 	</div>
 
 	<div class="info">

--- a/packages/ThemeDefault/src/function.latte
+++ b/packages/ThemeDefault/src/function.latte
@@ -7,9 +7,9 @@
 <div id="content" class="function">
 	<h1 n:class="$function->deprecated ? deprecated">Function {$function->shortName}</h1>
 
-	{var $longDescription = ($function|longDescription)}
-	<div class="description" n:if="$longDescription">
-		{$function|longDescription|noescape}
+	{var $description = ($function|description)}
+	<div class="description" n:if="$description">
+		{$function|description|noescape}
 	</div>
 
 	<div class="info">
@@ -37,7 +37,7 @@
 		<td class="value"><code>{block|strip}
 			<var>{if $parameter->passedByReference}&amp; {/if}${$parameter->name}</var>{if $parameter->defaultValueAvailable} = {$parameter->defaultValueDefinition|highlightPHP:$function|noescape}{elseif $parameter->unlimited},…{/if}
 		{/block}</code></td>
-		<td>{$parameter->description|description:$function}</td>
+		<td>{$parameter->description|annotationDescription:$function}</td>
 	</tr>
 	</table>
 
@@ -48,7 +48,7 @@
 			{$annotations['return'][0]|typeLinks:$function|noescape}
 		</code></td>
 		<td>
-			{$annotations['return'][0]|description:$function|noescape}
+			{$annotations['return'][0]|annotationDescription:$function|noescape}
 		</td>
 	</tr>
 	</table>
@@ -60,7 +60,7 @@
 			{$throws|typeLinks:$function|noescape}
 		</code></td>
 		<td>
-			{$throws|description:$function|noescape}
+			{$throws|annotationDescription:$function|noescape}
 		</td>
 	</tr>
 	</table>

--- a/packages/ThemeDefault/src/js/main.js
+++ b/packages/ThemeDefault/src/js/main.js
@@ -5,7 +5,6 @@ $(window).load(function() {
 	var $rightInner = $('#rightInner');
 	var $splitter = $('#splitter');
 	var $groups = $('#groups');
-	var $content = $('#content');
 
 	// Menu
 

--- a/packages/ThemeDefault/src/js/main.js
+++ b/packages/ThemeDefault/src/js/main.js
@@ -128,24 +128,6 @@ $(window).load(function() {
 		$caption.click();
 	}
 
-	// Open details
-	if (ApiGen.config.options.elementDetailsCollapsed) {
-		var trCollapsed = true;
-		$('tr', $content).filter(':has(.detailed)')
-			.click(function() {
-				var $this = $(this);
-				if (trCollapsed) {
-					$('.short', $this).hide();
-					$('.detailed', $this).show();
-					trCollapsed = false;
-				} else {
-					$('.short', $this).show();
-					$('.detailed', $this).hide();
-					trCollapsed = true;
-				}
-			});
-	}
-
 	// Splitter
 	var splitterWidth = $splitter.width();
 	var splitterPosition = $.cookie('splitter') ? parseInt($.cookie('splitter')) : null;

--- a/packages/ThemeDefault/src/js/main.js
+++ b/packages/ThemeDefault/src/js/main.js
@@ -95,39 +95,6 @@ $(window).load(function() {
 				return !autocompleteFound && '' !== $('#search input[name=cx]').val();
 			});
 
-	// Save natural order
-	$('table.summary tr[data-order]', $content).each(function(index) {
-		do {
-			index = '0' + index;
-		} while (index.length < 3);
-		$(this).attr('data-order-natural', index);
-	});
-
-	// Switch between natural and alphabetical order
-	var $caption = $('table.summary', $content)
-		.filter(':has(tr[data-order])')
-			.find('caption');
-	$caption
-		.click(function() {
-			var $this = $(this);
-			var order = $this.data('order') || 'natural';
-			order = 'natural' === order ? 'alphabetical' : 'natural';
-			$this.data('order', order);
-			$.cookie('order', order, {expires: 365});
-			var attr = 'alphabetical' === order ? 'data-order' : 'data-order-natural';
-			$this
-				.closest('table')
-					.find('tr').sortElements(function(a, b) {
-						return $(a).attr(attr) > $(b).attr(attr) ? 1 : -1;
-					});
-			return false;
-		})
-		.addClass('switchable')
-		.attr('title', 'Switch between natural and alphabetical order');
-	if ((null === $.cookie('order') && 'alphabetical' === ApiGen.config.options.elementsOrder) || 'alphabetical' === $.cookie('order')) {
-		$caption.click();
-	}
-
 	// Splitter
 	var splitterWidth = $splitter.width();
 	var splitterPosition = $.cookie('splitter') ? parseInt($.cookie('splitter')) : null;

--- a/packages/ThemeDefault/src/overview.latte
+++ b/packages/ThemeDefault/src/overview.latte
@@ -12,7 +12,7 @@
 	<table class="summary" id="namespaces" n:if="$namespaces">
 		<caption>Namespaces summary</caption>
 		{foreach $namespaces as $namespace}
-			{continueIf ($config->main && 0 !== strpos($namespace, $config->main)) || $namespace === 'PHP'}
+			{continueIf $namespace === 'PHP'}
 			<tr>
 				{var $group = true}
 				<td class="name"><a href="{$namespace|namespaceUrl}">{$namespace}</a></td>

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -68,11 +68,6 @@ final class Configuration implements ConfigurationInterface
         return $this->options[ConfigurationOptions::VISIBILITY_LEVELS];
     }
 
-    public function getMain(): string
-    {
-        return $this->options[ConfigurationOptions::MAIN];
-    }
-
     /**
      * @return string[]
      */

--- a/src/Configuration/ConfigurationOptions.php
+++ b/src/Configuration/ConfigurationOptions.php
@@ -52,11 +52,6 @@ final class ConfigurationOptions
     /**
      * @var string
      */
-    public const MAIN = 'main';
-
-    /**
-     * @var string
-     */
     public const SOURCE = 'source';
 
     /**

--- a/src/Configuration/ConfigurationOptionsResolver.php
+++ b/src/Configuration/ConfigurationOptionsResolver.php
@@ -45,7 +45,6 @@ final class ConfigurationOptionsResolver
         ConfigurationOptions::BASE_URL => '',
         ConfigurationOptions::CONFIG => '',
         ConfigurationOptions::FORCE_OVERWRITE => false,
-        ConfigurationOptions::MAIN => '',
         ConfigurationOptions::TEMPLATE_CONFIG => null,
         // helpers - @todo: remove
         ConfigurationOptions::VISIBILITY_LEVELS => [],

--- a/src/Configuration/Theme/ThemeConfigOptionsResolver.php
+++ b/src/Configuration/Theme/ThemeConfigOptionsResolver.php
@@ -15,9 +15,6 @@ final class ThemeConfigOptionsResolver extends Nette\Object
      */
     private $defaults = [
         'name' => '',
-        'options' => [
-            'elementDetailsCollapsed' => true,
-        ],
         ThemeConfigOptions::RESOURCES => [
             'resources' => 'resources'
         ],

--- a/src/Contracts/Configuration/ConfigurationInterface.php
+++ b/src/Contracts/Configuration/ConfigurationInterface.php
@@ -31,11 +31,6 @@ interface ConfigurationInterface
     public function getVisibilityLevel(): int;
 
     /**
-     * Return name of main library
-     */
-    public function getMain(): string;
-
-    /**
      * List of annotations.
      *
      * @return string[]

--- a/src/Contracts/Parser/Elements/ElementFilterInterface.php
+++ b/src/Contracts/Parser/Elements/ElementFilterInterface.php
@@ -8,12 +8,6 @@ interface ElementFilterInterface
 {
     /**
      * @param ElementReflectionInterface[] $elements
-     * @return ElementReflectionInterface[]
-     */
-    public function filterForMain(array $elements): array;
-
-    /**
-     * @param ElementReflectionInterface[] $elements
      * @param string $annotation
      * @return ElementReflectionInterface[]
      */

--- a/src/Contracts/Parser/Reflection/ElementReflectionInterface.php
+++ b/src/Contracts/Parser/Reflection/ElementReflectionInterface.php
@@ -6,8 +6,6 @@ use ApiGen\Contracts\Parser\Reflection\Behavior\NamedInterface;
 
 interface ElementReflectionInterface extends NamedInterface
 {
-    public function isMain(): bool;
-
     public function isDocumented(): bool;
 
     public function isDeprecated(): bool;

--- a/src/Contracts/Parser/Reflection/ElementReflectionInterface.php
+++ b/src/Contracts/Parser/Reflection/ElementReflectionInterface.php
@@ -41,9 +41,7 @@ interface ElementReflectionInterface extends NamedInterface
 
     public function hasAnnotation(string $name): bool;
 
-    public function getShortDescription(): string;
-
-    public function getLongDescription(): string;
+    public function getDescription(): string;
 
     /**
      * @return string|bool

--- a/src/Parser/Elements/ElementExtractor.php
+++ b/src/Parser/Elements/ElementExtractor.php
@@ -53,8 +53,7 @@ final class ElementExtractor implements ElementExtractorInterface
         $elements[Elements::PROPERTIES] = [];
 
         foreach ($this->elementStorage->getElements() as $type => $elementList) {
-            $elementsForMain = $this->elementFilter->filterForMain($elementList);
-            $elements[$type] += $this->elementFilter->filterByAnnotation($elementsForMain, $annotation);
+            $elements[$type] += $this->elementFilter->filterByAnnotation($elementList, $annotation);
 
             if ($type === Elements::CONSTANTS || $type === Elements::FUNCTIONS) {
                 continue;
@@ -62,10 +61,6 @@ final class ElementExtractor implements ElementExtractorInterface
 
             foreach ($elementList as $class) {
                 /** @var ClassReflectionInterface $class */
-                if (! $class->isMain()) {
-                    continue;
-                }
-
                 $elements[Elements::METHODS] = $this->extractByAnnotationAndMerge(
                     $class->getOwnMethods(),
                     $annotation,

--- a/src/Parser/Elements/ElementFilter.php
+++ b/src/Parser/Elements/ElementFilter.php
@@ -11,17 +11,6 @@ final class ElementFilter implements ElementFilterInterface
      * @param ElementReflectionInterface[] $elements
      * @return ElementReflectionInterface[]
      */
-    public function filterForMain(array $elements): array
-    {
-        return array_filter($elements, function (ElementReflectionInterface $element) {
-            return $element->isMain();
-        });
-    }
-
-    /**
-     * @param ElementReflectionInterface[] $elements
-     * @return ElementReflectionInterface[]
-     */
     public function filterByAnnotation(array $elements, string $annotation): array
     {
         return array_filter($elements, function (ElementReflectionInterface $element) use ($annotation) {

--- a/src/Parser/Elements/NamespaceSorter.php
+++ b/src/Parser/Elements/NamespaceSorter.php
@@ -2,7 +2,6 @@
 
 namespace ApiGen\Parser\Elements;
 
-use ApiGen\Contracts\Configuration\ConfigurationInterface;
 use ApiGen\Contracts\Parser\Elements\ElementsInterface;
 use ApiGen\Contracts\Parser\Elements\NamespaceSorterInterface;
 
@@ -14,19 +13,13 @@ final class NamespaceSorter implements NamespaceSorterInterface
     private $namespaces;
 
     /**
-     * @var ConfigurationInterface
-     */
-    private $configuration;
-
-    /**
      * @var ElementsInterface
      */
     private $elements;
 
-    public function __construct(ElementsInterface $elements, ConfigurationInterface $configuration)
+    public function __construct(ElementsInterface $elements)
     {
         $this->elements = $elements;
-        $this->configuration = $configuration;
     }
 
     /**
@@ -49,7 +42,7 @@ final class NamespaceSorter implements NamespaceSorterInterface
         }
 
         uksort($this->namespaces, function ($one, $two) {
-            return $this->compareNamespaceNames($one, $two, $this->configuration->getMain());
+            return $this->compareNamespaceNames($one, $two);
         });
 
         return $this->namespaces;
@@ -84,20 +77,11 @@ final class NamespaceSorter implements NamespaceSorterInterface
         }
     }
 
-    private function compareNamespaceNames(string $firstNamespace, string $secondNamespace, string $main): int
+    private function compareNamespaceNames(string $firstNamespace, string $secondNamespace): int
     {
         // \ as separator has to be first
         $firstNamespace = str_replace('\\', ' ', $firstNamespace);
         $secondNamespace = str_replace('\\', ' ', $secondNamespace);
-
-        // @todo: battle ship?
-        if ($main) {
-            if (strpos($firstNamespace, $main) === 0 && strpos($secondNamespace, $main) !== 0) {
-                return -1;
-            } elseif (strpos($firstNamespace, $main) !== 0 && strpos($secondNamespace, $main) === 0) {
-                return 1;
-            }
-        }
 
         return strcasecmp($firstNamespace, $secondNamespace);
     }

--- a/src/Parser/Reflection/AbstractReflectionElement.php
+++ b/src/Parser/Reflection/AbstractReflectionElement.php
@@ -31,12 +31,6 @@ abstract class AbstractReflectionElement extends AbstractReflection implements E
         return $this->reflection->getEndPosition();
     }
 
-    public function isMain(): bool
-    {
-        $main = $this->configuration->getMain();
-        return empty($main) || strpos($this->getName(), $main) === 0;
-    }
-
     public function isDocumented(): bool
     {
         if ($this->isDocumented === null) {

--- a/src/Parser/Reflection/AbstractReflectionElement.php
+++ b/src/Parser/Reflection/AbstractReflectionElement.php
@@ -98,22 +98,7 @@ abstract class AbstractReflectionElement extends AbstractReflection implements E
         return $this->reflection->getNamespaceAliases();
     }
 
-    public function getShortDescription(): string
-    {
-        $short = $this->reflection->getAnnotation(ReflectionAnnotation::SHORT_DESCRIPTION);
-        if (! empty($short)) {
-            return $short;
-        }
-
-        if ($this instanceof ReflectionProperty || $this instanceof ReflectionConstant) {
-            $var = $this->getAnnotation('var');
-            [, $short] = preg_split('~\s+|$~', $var[0], 2);
-        }
-
-        return (string) $short;
-    }
-
-    public function getLongDescription(): string
+    public function getDescription(): string
     {
         $short = $this->getShortDescription();
         $long = $this->reflection->getAnnotation(ReflectionAnnotation::LONG_DESCRIPTION);
@@ -188,5 +173,20 @@ abstract class AbstractReflectionElement extends AbstractReflection implements E
         }
 
         return $annotations;
+    }
+
+    private function getShortDescription(): string
+    {
+        $short = $this->reflection->getAnnotation(ReflectionAnnotation::SHORT_DESCRIPTION);
+        if (! empty($short)) {
+            return $short;
+        }
+
+        if ($this instanceof ReflectionProperty || $this instanceof ReflectionConstant) {
+            $var = $this->getAnnotation('var');
+            [, $short] = preg_split('~\s+|$~', $var[0], 2);
+        }
+
+        return (string) $short;
     }
 }

--- a/src/Templating/Filters/UrlFilters.php
+++ b/src/Templating/Filters/UrlFilters.php
@@ -125,20 +125,15 @@ final class UrlFilters extends Filters
         return implode('|', $links);
     }
 
-    public function description(string $annotation, ElementReflectionInterface $reflectionElement): string
+    public function annotationDescription(string $annotation, ElementReflectionInterface $reflectionElement): string
     {
         $description = trim(strpbrk($annotation, "\n\r\t $")) ?: $annotation;
         return $this->doc($description, $reflectionElement);
     }
 
-    public function shortDescription(ElementReflectionInterface $reflectionElement): string
+    public function description(ElementReflectionInterface $element): string
     {
-        return $this->doc($reflectionElement->getShortDescription(), $reflectionElement);
-    }
-
-    public function longDescription(ElementReflectionInterface $element): string
-    {
-        $long = $element->getLongDescription();
+        $long = $element->getDescription();
 
         // Merge lines
         $long = preg_replace_callback('~(?:<(code|pre)>.+?</\1>)|([^<]*)~s', function ($matches) {

--- a/src/Templating/TemplateElementsLoader.php
+++ b/src/Templating/TemplateElementsLoader.php
@@ -5,9 +5,7 @@ namespace ApiGen\Templating;
 use ApiGen\Configuration\ConfigurationOptions;
 use ApiGen\Contracts\Configuration\ConfigurationInterface;
 use ApiGen\Contracts\Parser\Elements\ElementStorageInterface;
-use ApiGen\Contracts\Parser\Reflection\ElementReflectionInterface;
 use ApiGen\Parser\Elements\AutocompleteElements;
-use Closure;
 
 final class TemplateElementsLoader
 {
@@ -46,13 +44,6 @@ final class TemplateElementsLoader
         $template->setParameters($this->getParameters());
     }
 
-    private function getMainFilter(): Closure
-    {
-        return function (ElementReflectionInterface $element) {
-            return $element->isMain();
-        };
-    }
-
     /**
      * @return mixed[]
      */
@@ -66,12 +57,12 @@ final class TemplateElementsLoader
                 'constant' => null,
                 'function' => null,
                 'namespaces' => array_keys($this->elementStorage->getNamespaces()),
-                'classes' => array_filter($this->elementStorage->getClasses(), $this->getMainFilter()),
-                'interfaces' => array_filter($this->elementStorage->getInterfaces(), $this->getMainFilter()),
-                'traits' => array_filter($this->elementStorage->getTraits(), $this->getMainFilter()),
-                'exceptions' => array_filter($this->elementStorage->getExceptions(), $this->getMainFilter()),
-                'constants' => array_filter($this->elementStorage->getConstants(), $this->getMainFilter()),
-                'functions' => array_filter($this->elementStorage->getFunctions(), $this->getMainFilter()),
+                'classes' => array_filter($this->elementStorage->getClasses()),
+                'interfaces' => array_filter($this->elementStorage->getInterfaces()),
+                'traits' => array_filter($this->elementStorage->getTraits()),
+                'exceptions' => array_filter($this->elementStorage->getExceptions()),
+                'constants' => array_filter($this->elementStorage->getConstants()),
+                'functions' => array_filter($this->elementStorage->getFunctions()),
                 'elements' => $this->autocompleteElements->getElements()
             ];
 

--- a/tests/Parser/Elements/ElementExtractorTest.php
+++ b/tests/Parser/Elements/ElementExtractorTest.php
@@ -48,8 +48,6 @@ final class ElementExtractorTest extends TestCase
             ->willReturn(true);
         $reflectionClassMock->method('getOwnMethods')
             ->willReturn([]);
-        $reflectionClassMock->method('isMain')
-            ->willReturn(true);
         $reflectionClassMock->method('hasAnnotation')
             ->with('deprecated')
             ->willReturn(true);

--- a/tests/Parser/Elements/ElementFilterTest.php
+++ b/tests/Parser/Elements/ElementFilterTest.php
@@ -18,21 +18,6 @@ final class ElementFilterTest extends TestCase
         $this->elementFilter = new ElementFilter;
     }
 
-    public function testFilterForMain(): void
-    {
-        $reflectionElement = $this->createMock(ElementReflectionInterface::class);
-        $reflectionElement->method('isMain')
-            ->willReturn(true);
-
-        $reflectionElement2 = $this->createMock(ElementReflectionInterface::class);
-        $reflectionElement2->method('isMain')
-            ->willReturn(false);
-
-        $elements = [$reflectionElement, $reflectionElement2];
-
-        $this->assertCount(1, $this->elementFilter->filterForMain($elements));
-    }
-
     public function testFilterByAnnotation(): void
     {
         $reflectionElement = $this->createMock(ElementReflectionInterface::class);

--- a/tests/Parser/Elements/NamespaceSorterTest.php
+++ b/tests/Parser/Elements/NamespaceSorterTest.php
@@ -20,8 +20,6 @@ final class NamespaceSorterTest extends TestCase
     protected function setUp(): void
     {
         $configurationMock = $this->createMock(ConfigurationInterface::class);
-        $configurationMock->method('getMain')
-            ->willReturn('');
 
         $this->namespaceSorter = new NamespaceSorter(new Elements, $configurationMock);
     }
@@ -80,11 +78,11 @@ final class NamespaceSorterTest extends TestCase
     /**
      * @dataProvider getCompareNamespacesData()
      */
-    public function testCompareNamespaces(string $one, string $two, string $main, int $expected): void
+    public function testCompareNamespaces(string $one, string $two, int $expected): void
     {
         $this->assertSame(
             $expected,
-            MethodInvoker::callMethodOnObject($this->namespaceSorter, 'compareNamespaceNames', [$one, $two, $main])
+            MethodInvoker::callMethodOnObject($this->namespaceSorter, 'compareNamespaceNames', [$one, $two])
         );
     }
 
@@ -94,10 +92,8 @@ final class NamespaceSorterTest extends TestCase
     public function getCompareNamespacesData(): array
     {
         return [
-            ['GroupOne', 'OtherGroup', '', -8],
-            ['One', 'Two', '', -5],
-            ['One', 'Two', 'On', -1],
-            ['One', 'Two', 'Tw', 1],
+            ['GroupOne', 'OtherGroup', -8],
+            ['One', 'Two', -5],
         ];
     }
 }

--- a/tests/Parser/Reflection/ReflectionElementTest.php
+++ b/tests/Parser/Reflection/ReflectionElementTest.php
@@ -69,14 +69,9 @@ final class ReflectionElementTest extends TestCase
         $this->assertSame([], $this->reflectionClass->getNamespaceAliases());
     }
 
-    public function testGetShortDescription(): void
+    public function testGetDescription(): void
     {
-        $this->assertSame('This is some description', $this->reflectionClass->getShortDescription());
-    }
-
-    public function testGetLongDescription(): void
-    {
-        $this->assertSame('This is some description', $this->reflectionClass->getLongDescription());
+        $this->assertSame('This is some description', $this->reflectionClass->getDescription());
     }
 
     public function testGetDocComment(): void

--- a/tests/Parser/Reflection/ReflectionElementTest.php
+++ b/tests/Parser/Reflection/ReflectionElementTest.php
@@ -39,11 +39,6 @@ final class ReflectionElementTest extends TestCase
         $this->assertSame(69, $this->reflectionClass->getEndPosition());
     }
 
-    public function testIsMain(): void
-    {
-        $this->assertTrue($this->reflectionClass->isMain());
-    }
-
     public function testIsDocumented(): void
     {
         $this->assertTrue($this->reflectionClass->isDocumented());
@@ -137,8 +132,6 @@ final class ReflectionElementTest extends TestCase
         $configurationMock = $this->createMock(ConfigurationInterface::class);
         $configurationMock->method('getVisibilityLevel')
             ->willReturn(ReflectionProperty::IS_PUBLIC);
-        $configurationMock->method('getMain')
-            ->willReturn('');
 
         return new ReflectionFactory($configurationMock, $parserStorageMock);
     }

--- a/tests/Templating/Filters/UrlFiltersTest.php
+++ b/tests/Templating/Filters/UrlFiltersTest.php
@@ -145,7 +145,7 @@ final class UrlFiltersTest extends AbstractContainerAwareTestCase
         );
     }
 
-    public function testDescription(): void
+    public function testAnnotationDescription(): void
     {
         $docBlock = <<<DOC
 /**
@@ -160,32 +160,20 @@ DOC;
  * with more rows
  */
 EXP;
-        $this->assertSame($expected, $this->urlFilters->description($docBlock, $reflectionElementMock));
+        $this->assertSame($expected, $this->urlFilters->annotationDescription($docBlock, $reflectionElementMock));
     }
 
-    public function testShortDescription(): void
-    {
-        $reflectionElementMock = $this->createMock(ElementReflectionInterface::class);
-        $reflectionElementMock->method('getShortDescription')
-            ->willReturn('Some short description');
-
-        $this->assertSame(
-            'Some short description',
-            $this->urlFilters->shortDescription($reflectionElementMock)
-        );
-    }
-
-    public function testLongDescription(): void
+    public function testDescription(): void
     {
         $longDescription = <<<DOC
 Some long description with example:
 <code>echo "hi";</code>
 DOC;
         $reflectionElementMock = $this->createMock(ElementReflectionInterface::class);
-        $reflectionElementMock->method('getLongDescription')
+        $reflectionElementMock->method('getDescription')
             ->willReturn($longDescription);
 
-        $this->assertSame($longDescription, $this->urlFilters->longDescription($reflectionElementMock));
+        $this->assertSame($longDescription, $this->urlFilters->description($reflectionElementMock));
     }
 
     public function testHighlightPhp(): void


### PR DESCRIPTION
This is kind of non-intuitive feature, hides relevant content, broken on mobile and difficult to to use.
Sometimes I have to double click the method, to see anything, sometimes just once. Then it hides, pop-ups etc.

This PR will show everything that is relevant to the user.

---

As for main, I've checked few ApiGen output and none is using it. Also it's unusable for multiple sorting (logic step). 

I'd move attention to arguments `source` and `exclude`, where it makes more sense.

---

Also, since short description is not used anymore, move short and long description to simply `description`.