### PR TITLE
fix #804 on 4.2 branch

### DIFF
--- a/src/Generator/Resolvers/RelativePathResolver.php
+++ b/src/Generator/Resolvers/RelativePathResolver.php
@@ -41,7 +41,9 @@ class RelativePathResolver
      */
     public function getRelativePath($fileName)
     {
+        $fileName = $this->fileSystem->normalizePath($fileName);
         foreach ($this->configuration->getOption(CO::SOURCE) as $directory) {
+            $directory = $this->fileSystem->normalizePath($directory);
             if (strpos($fileName, $directory) === 0) {
                 return $this->getFileNameWithoutSourcePath($fileName, $directory);
             }
@@ -58,8 +60,9 @@ class RelativePathResolver
      */
     private function getFileNameWithoutSourcePath($fileName, $directory)
     {
-        $directory = rtrim($directory, DIRECTORY_SEPARATOR);
-        $fileName = substr($fileName, strlen($directory) + 1);
-        return $this->fileSystem->normalizePath($fileName);
+        $directory = $this->fileSystem->normalizePath($directory);
+        $fileName = $this->fileSystem->normalizePath($fileName);
+        $directory = rtrim($directory, '/');
+        return substr($fileName, strlen($directory) + 1);
     }
 }

--- a/src/Theme/ThemeConfigPathResolver.php
+++ b/src/Theme/ThemeConfigPathResolver.php
@@ -42,7 +42,7 @@ class ThemeConfigPathResolver
         ];
 
         foreach ($allowedPaths as $allowedPath) {
-            $absolutePath = FileSystem::getAbsolutePath($allowedPath . '/' . $path);
+            $absolutePath = $allowedPath . '/' . ltrim($path, '/');
             if (file_exists($absolutePath)) {
                 return $absolutePath;
             }

--- a/src/Theme/ThemeConfigPathResolver.php
+++ b/src/Theme/ThemeConfigPathResolver.php
@@ -10,6 +10,7 @@
 namespace ApiGen\Theme;
 
 use ApiGen\Configuration\Exceptions\ConfigurationException;
+use ApiGen\Utils\FileSystem;
 
 class ThemeConfigPathResolver
 {
@@ -41,7 +42,7 @@ class ThemeConfigPathResolver
         ];
 
         foreach ($allowedPaths as $allowedPath) {
-            $absolutePath = $allowedPath . '/' . ltrim($path, DIRECTORY_SEPARATOR);
+            $absolutePath = FileSystem::getAbsolutePath($allowedPath . '/' . $path);
             if (file_exists($absolutePath)) {
                 return $absolutePath;
             }

--- a/tests/Console/Command/GenerateCommandExecuteTest.php
+++ b/tests/Console/Command/GenerateCommandExecuteTest.php
@@ -30,12 +30,12 @@ class GenerateCommandExecuteTest extends ContainerAwareTestCase
 
     public function testExecute()
     {
-        $this->assertFileNotExists(TEMP_DIR . '/Api/index.html');
+        $this->assertFileNotExists(TEMP_DIR . '/api/index.html');
 
         $inputMock = Mockery::mock(InputInterface::class);
         $inputMock->shouldReceive('getOptions')->andReturn([
             'config' => null,
-            'destination' => TEMP_DIR . '/Api',
+            'destination' => TEMP_DIR . '/api',
             'source' => __DIR__ . '/Source'
         ]);
         $outputMock = Mockery::mock(OutputInterface::class);
@@ -51,7 +51,7 @@ class GenerateCommandExecuteTest extends ContainerAwareTestCase
             MethodInvoker::callMethodOnObject($this->generateCommand, 'execute', [$inputMock, $outputMock])
         );
 
-        $this->assertFileExists(TEMP_DIR . '/Api/index.html');
+        $this->assertFileExists(TEMP_DIR . '/api/index.html');
     }
 
 

--- a/tests/Console/Command/GenerateCommandPrepareOptionsTest.php
+++ b/tests/Console/Command/GenerateCommandPrepareOptionsTest.php
@@ -16,10 +16,16 @@ class GenerateCommandPrepareOptionsTest extends ContainerAwareTestCase
      */
     private $generateCommand;
 
+    /**
+     * @var FileSystem
+     */
+    private $fileSystem;
+
 
     protected function setUp()
     {
         $this->generateCommand = $this->container->getByType(GenerateCommand::class);
+        $this->fileSystem = new FileSystem;
     }
 
 
@@ -51,7 +57,7 @@ class GenerateCommandPrepareOptionsTest extends ContainerAwareTestCase
             'source' => __DIR__
         ]]);
 
-        $this->assertSame(FileSystem::getAbsolutePath(TEMP_DIR . '/api'), $options['destination']);
+        $this->assertSame($this->fileSystem->getAbsolutePath(TEMP_DIR . '/api'), $options['destination']);
     }
 
 
@@ -66,7 +72,7 @@ class GenerateCommandPrepareOptionsTest extends ContainerAwareTestCase
         $options = MethodInvoker::callMethodOnObject($this->generateCommand, 'prepareOptions', [
             $configAndDestinationOptions
         ]);
-        $this->assertSame(FileSystem::getAbsolutePath(__DIR__ . '/../../../src'), $options['source'][0]);
+        $this->assertSame($this->fileSystem->getAbsolutePath(__DIR__ . '/../../../src'), $options['source'][0]);
     }
 
 

--- a/tests/Console/Command/GenerateCommandPrepareOptionsTest.php
+++ b/tests/Console/Command/GenerateCommandPrepareOptionsTest.php
@@ -6,6 +6,7 @@ use ApiGen\Configuration\Exceptions\ConfigurationException;
 use ApiGen\Console\Command\GenerateCommand;
 use ApiGen\Tests\ContainerAwareTestCase;
 use ApiGen\Tests\MethodInvoker;
+use ApiGen\Utils\FileSystem;
 
 class GenerateCommandPrepareOptionsTest extends ContainerAwareTestCase
 {
@@ -50,7 +51,7 @@ class GenerateCommandPrepareOptionsTest extends ContainerAwareTestCase
             'source' => __DIR__
         ]]);
 
-        $this->assertSame(TEMP_DIR . '/api', $options['destination']);
+        $this->assertSame(FileSystem::getAbsolutePath(TEMP_DIR . '/api'), $options['destination']);
     }
 
 
@@ -65,7 +66,7 @@ class GenerateCommandPrepareOptionsTest extends ContainerAwareTestCase
         $options = MethodInvoker::callMethodOnObject($this->generateCommand, 'prepareOptions', [
             $configAndDestinationOptions
         ]);
-        $this->assertSame(realpath(__DIR__ . '/../../../src'), $options['source'][0]);
+        $this->assertSame(FileSystem::getAbsolutePath(__DIR__ . '/../../../src'), $options['source'][0]);
     }
 
 

--- a/tests/Templating/TemplateNavigatorTest.php
+++ b/tests/Templating/TemplateNavigatorTest.php
@@ -27,6 +27,10 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
      */
     private $templateNavigator;
 
+    /**
+     * @var FileSystem
+     */
+    private $fileSystem;
 
     protected function setUp()
     {
@@ -64,13 +68,14 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
             $elementUrlFactoryMock,
             $namespaceAndPackageUrlFiltersMock
         );
+        $this->fileSystem = new FileSystem;
     }
 
 
     public function testGetTemplateFileName()
     {
         $this->assertSame(
-            FileSystem::getAbsolutePath(TEMP_DIR . '/api/index.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/index.html'),
             $this->templateNavigator->getTemplateFileName('overview')
         );
     }
@@ -88,7 +93,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
     public function testGetTemplatePathForNamespace()
     {
         $this->assertSame(
-            FileSystem::getAbsolutePath(TEMP_DIR . '/api/namespace-MyNamespace.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/namespace-MyNamespace.html'),
             $this->templateNavigator->getTemplatePathForNamespace('MyNamespace')
         );
     }
@@ -97,7 +102,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
     public function testGetTemplatePathForPackage()
     {
         $this->assertSame(
-            FileSystem::getAbsolutePath(TEMP_DIR . '/api/package-MyPackage.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/package-MyPackage.html'),
             $this->templateNavigator->getTemplatePathForPackage('MyPackage')
         );
     }
@@ -109,7 +114,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
         $classReflectionMock->shouldReceive('getName')->andReturn('SomeClass');
 
         $this->assertSame(
-            FileSystem::getAbsolutePath(TEMP_DIR . '/api/class-SomeClass.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/class-SomeClass.html'),
             $this->templateNavigator->getTemplatePathForClass($classReflectionMock)
         );
     }
@@ -121,7 +126,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
         $constantReflectionMock->shouldReceive('getName')->andReturn('SomeConstant');
 
         $this->assertSame(
-            FileSystem::getAbsolutePath(TEMP_DIR . '/api/constant-SomeConstant.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/constant-SomeConstant.html'),
             $this->templateNavigator->getTemplatePathForConstant($constantReflectionMock)
         );
     }
@@ -133,7 +138,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
         $functionReflectionMock->shouldReceive('getName')->andReturn('SomeFunction');
 
         $this->assertSame(
-            FileSystem::getAbsolutePath(TEMP_DIR . '/api/function-SomeFunction.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/function-SomeFunction.html'),
             $this->templateNavigator->getTemplatePathForFunction($functionReflectionMock)
         );
     }
@@ -145,7 +150,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
         $classReflectionMock->shouldReceive('getName')->andReturn('SomeClass');
 
         $this->assertSame(
-            FileSystem::getAbsolutePath(TEMP_DIR . '/api/source-code-SomeClass.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/source-code-SomeClass.html'),
             $this->templateNavigator->getTemplatePathForSourceElement($classReflectionMock)
         );
     }

--- a/tests/Templating/TemplateNavigatorTest.php
+++ b/tests/Templating/TemplateNavigatorTest.php
@@ -11,6 +11,7 @@ use ApiGen\Templating\Filters\NamespaceAndPackageUrlFilters;
 use ApiGen\Templating\Filters\SourceFilters;
 use ApiGen\Templating\TemplateNavigator;
 use ApiGen\Tests\ContainerAwareTestCase;
+use ApiGen\Utils\FileSystem;
 use Mockery;
 
 class TemplateNavigatorTest extends ContainerAwareTestCase
@@ -69,7 +70,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
     public function testGetTemplateFileName()
     {
         $this->assertSame(
-            TEMP_DIR . '/api/index.html',
+            FileSystem::getAbsolutePath(TEMP_DIR . '/api/index.html'),
             $this->templateNavigator->getTemplateFileName('overview')
         );
     }
@@ -87,7 +88,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
     public function testGetTemplatePathForNamespace()
     {
         $this->assertSame(
-            TEMP_DIR . '/api/namespace-MyNamespace.html',
+            FileSystem::getAbsolutePath(TEMP_DIR . '/api/namespace-MyNamespace.html'),
             $this->templateNavigator->getTemplatePathForNamespace('MyNamespace')
         );
     }
@@ -96,7 +97,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
     public function testGetTemplatePathForPackage()
     {
         $this->assertSame(
-            TEMP_DIR . '/api/package-MyPackage.html',
+            FileSystem::getAbsolutePath(TEMP_DIR . '/api/package-MyPackage.html'),
             $this->templateNavigator->getTemplatePathForPackage('MyPackage')
         );
     }
@@ -108,7 +109,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
         $classReflectionMock->shouldReceive('getName')->andReturn('SomeClass');
 
         $this->assertSame(
-            TEMP_DIR . '/api/class-SomeClass.html',
+            FileSystem::getAbsolutePath(TEMP_DIR . '/api/class-SomeClass.html'),
             $this->templateNavigator->getTemplatePathForClass($classReflectionMock)
         );
     }
@@ -120,7 +121,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
         $constantReflectionMock->shouldReceive('getName')->andReturn('SomeConstant');
 
         $this->assertSame(
-            TEMP_DIR . '/api/constant-SomeConstant.html',
+            FileSystem::getAbsolutePath(TEMP_DIR . '/api/constant-SomeConstant.html'),
             $this->templateNavigator->getTemplatePathForConstant($constantReflectionMock)
         );
     }
@@ -132,7 +133,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
         $functionReflectionMock->shouldReceive('getName')->andReturn('SomeFunction');
 
         $this->assertSame(
-            TEMP_DIR . '/api/function-SomeFunction.html',
+            FileSystem::getAbsolutePath(TEMP_DIR . '/api/function-SomeFunction.html'),
             $this->templateNavigator->getTemplatePathForFunction($functionReflectionMock)
         );
     }
@@ -144,7 +145,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
         $classReflectionMock->shouldReceive('getName')->andReturn('SomeClass');
 
         $this->assertSame(
-            TEMP_DIR . '/api/source-code-SomeClass.html',
+            FileSystem::getAbsolutePath(TEMP_DIR . '/api/source-code-SomeClass.html'),
             $this->templateNavigator->getTemplatePathForSourceElement($classReflectionMock)
         );
     }

--- a/tests/Theme/ThemeConfigPathResolverTest.php
+++ b/tests/Theme/ThemeConfigPathResolverTest.php
@@ -3,7 +3,7 @@
 namespace ApiGen\Tests\Theme;
 
 use ApiGen\Theme\ThemeConfigPathResolver;
-use Mockery;
+use ApiGen\Utils\FileSystem;
 use PHPUnit_Framework_TestCase;
 
 class ThemeConfigPathResolverTest extends PHPUnit_Framework_TestCase
@@ -14,9 +14,9 @@ class ThemeConfigPathResolverTest extends PHPUnit_Framework_TestCase
         $themeConfigPathResolver = new ThemeConfigPathResolver(__DIR__ . '/ThemeConfigPathResolverSource');
 
         $configPath = $themeConfigPathResolver->resolve('/config.neon');
-        $this->assertSame(__DIR__  . '/ThemeConfigPathResolverSource/config.neon', $configPath);
+        $this->assertSame(FileSystem::getAbsolutePath(__DIR__  . '/ThemeConfigPathResolverSource/config.neon'), $configPath);
 
         $configPath = $themeConfigPathResolver->resolve('config.neon');
-        $this->assertSame(__DIR__  . '/ThemeConfigPathResolverSource/config.neon', $configPath);
+        $this->assertSame(FileSystem::getAbsolutePath(__DIR__  . '/ThemeConfigPathResolverSource/config.neon'), $configPath);
     }
 }

--- a/tests/Theme/ThemeConfigPathResolverTest.php
+++ b/tests/Theme/ThemeConfigPathResolverTest.php
@@ -14,9 +14,9 @@ class ThemeConfigPathResolverTest extends PHPUnit_Framework_TestCase
         $themeConfigPathResolver = new ThemeConfigPathResolver(__DIR__ . '/ThemeConfigPathResolverSource');
 
         $configPath = $themeConfigPathResolver->resolve('/config.neon');
-        $this->assertSame(FileSystem::getAbsolutePath(__DIR__  . '/ThemeConfigPathResolverSource/config.neon'), $configPath);
+        $this->assertSame(__DIR__  . '/ThemeConfigPathResolverSource/config.neon', $configPath);
 
         $configPath = $themeConfigPathResolver->resolve('config.neon');
-        $this->assertSame(FileSystem::getAbsolutePath(__DIR__  . '/ThemeConfigPathResolverSource/config.neon'), $configPath);
+        $this->assertSame(__DIR__  . '/ThemeConfigPathResolverSource/config.neon', $configPath);
     }
 }

--- a/tests/Utils/Neon/NeonFile/NeonFileTest.php
+++ b/tests/Utils/Neon/NeonFile/NeonFileTest.php
@@ -25,6 +25,9 @@ class NeonFileTest extends PHPUnit_Framework_TestCase
     }
 
 
+    /**
+     * @requires OS Linux
+     */
     public function testFileNotReadable()
     {
         $dirPath = TEMP_DIR . '/some-dir';


### PR DESCRIPTION
Hi,

Just to get myself familiar with the sourcecode.

I have three concerns;
1. Should have this be done for the upcoming v5?
2. Is `FileSystem::normalizePath()` really necessary? This is what I think it describes its intended purpose, https://github.com/ApiGen/ApiGen/blob/4.2/tests/Utils/FileSystemTest.php#L24