### PR TITLE
Documentation section in README: Configuration and CLI commands / options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ parameter).
 
 #### Reference Configuration
 
-A reference configuration file with all of the available and support
-configuration options, together with their default values.
+A reference configuration file with all of the available and supported
+configuration options.
 
 ```neon
 # apigen.neon.dist

--- a/README.md
+++ b/README.md
@@ -124,22 +124,20 @@ debug: false                        # set to true to enable debug
 This section provides information on all available CLI commands and their
 options.
 
-To get a list of available `apigen` commands:
-
-    $ apigen list
-
-Main commands:
+Main ApiGen commands:
 
 - [generate](#generate) - generates API documentation.
-- `help` - display help for a specific command.
-- `list` - lists available commands.
+
+To get a list of available `apigen list` command. To get help on specific
+command use `apigen help`, i.e.:
+
+    $ apigen help generate
 
 #### Generate
 
-`generate` command is the main command which starts generation of API
-documentation. The command relies on reading data from [configuration
-files](#Configuration). If these are not available, then it will expect command
-line arguments passed to it.
+`generate` command is the main command which generates API documentation. The
+command relies either on passing it CLI options or reading data from
+[configuration files](#Configuration).
 
 A list of options accepted by `generate` command:
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,70 @@ vendor/bin/apigen generate --help
 
 ### Configuration
 
-This section provides information on all available coniguration options that
+This section provides information on all available configuration options that
 can be included in configuration files (`apigen.yml` or `apigen.neon`).
+
+#### Minimal Configuration
+
+A minimal configuration file:
+
+```neon
+# apigen.neon.dist
+# This is minimal configuration for ApiGen.
+source: [src]           # directory(-ies) to scan PHP files from
+destination: docs       # destination directory to generate API docs in
+```
+
+**Note!** The configuration files match CLI options for [generate](#generate)
+command. The only difference is that when defining these options in
+configuration file, you have to use `camelCased` format (i.e.
+`--annotation-groups` CLI options becomes `annotationGroups` configuration
+parameter).
+
+#### Reference Configuration
+
+A reference configuration file with all of the available and support
+configuration options, together with their default values.
+
+```neon
+# apigen.neon.dist
+# This is reference configuration for ApiGen. It contains all of the available
+# and supported configuration options, together with their default values.
+# source options
+source: [src]                       # Source directory(-ies) to build API docs for
+extensions: [php] # array           # A list of file extension to include when
+                                    # scanning source dir
+accessLevels: [public, protected]   # Access levels of methods and properties
+                                    # to include
+annotationGroups: [todo, deprecated]# Annotation Groups to include
+internal: false                     # Set to `true` to include @internal in API
+                                    # docs.
+#main: 'SomePrefix'                 # Elements with this name prefix will be
+                                    # first in the tree.
+php: false                          # Set to `true` to generate docs for PHP
+                                    # internal classes.
+noSourceCode: false                 # Set to `true` to NOT generate highlighted
+                                    # source code for elements.
+
+# destination / generated docs options
+destination: doc                    # Destination directory for API docs
+exclude: tests                      # A blob pattern to exclude from API docs
+                                    # generation.
+overwrite: true # bool              # Overwrite destination directory by
+                                    # default
+title: "ApiGen Docs"                # Title of generated API docs.
+baseUrl: http://apigen.org/api      # Base URL for generated API docs.
+templateConfig: path/to/config.neon # path to template configuration
+
+# templates parameters
+googleAnalytics: 123
+googleCseId: 456
+download: true                      # show a link to download API docs ZIP
+                                    # archive in the API docs
+
+# debug
+debug: false                        # set to true to enable debug
+```
 
 ### CLI Commands
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 [![Downloads](https://img.shields.io/packagist/dt/apigen/apigen.svg?style=flat-square)](https://packagist.org/packages/apigen/apigen)
 [![Latest stable](https://img.shields.io/packagist/v/apigen/apigen.svg?style=flat-square)](https://packagist.org/packages/apigen/apigen)
 
-
 Just look at [CakePHP Framework](http://api.cakephp.org/3.0/) or [Doctrine ORM API](http://www.doctrine-project.org/api/orm/2.4/).
-
 
 ## Requirements
 
@@ -52,11 +50,76 @@ For all available options, along with descriptions and default values, just run:
 vendor/bin/apigen generate --help
 ```
 
-*NOTE: In config files, options are camelCased (i.e. `accessLevel` for `--access-level`).*
+## Documentation
 
-Refer to the [wiki](https://github.com/ApiGen/ApiGen/wiki/supported-annotations) for all supported annotations.
+### Configuration
 
-## Testing
+This section provides information on all available coniguration options that
+can be included in configuration files (`apigen.yml` or `apigen.neon`).
+
+### CLI Commands
+
+This section provides information on all available CLI commands and their
+options.
+
+To get a list of available `apigen` commands:
+
+    $ apigen list
+
+Main commands:
+
+- [generate](#generate) - generates API documentation.
+- `help` - display help for a specific command.
+- `list` - lists available commands.
+
+#### Generate
+
+`generate` command is the main command which starts generation of API
+documentation. The command relies on reading data from [configuration
+files](#Configuration). If these are not available, then it will expect command
+line arguments passed to it.
+
+A list of options accepted by `generate` command:
+
+| Option                | Description                                         |
+| --------------------- | --------------------------------------------------- |
+| `--source` (`-s`)     | Source directory(-ies) to generate API docs for. **Multiple values are allowed**.
+| `--destination` (`-d`)| Destination directory for API docs.
+| `--access-levels`     | Access levels of methods and properties to be included in API docs [options: `public`, `protected`, `private`]. Default: `["public","protected"]`.
+| `--annotation-groups` | Generate page with elements with specific annotation.
+| `--config`            | Custom path to apigen configuration file. Default: `./apigen.neon`
+| `--google-cse-id`     | Custom Google Search Engine ID (for search box).
+| `--base-url`          | Base URL (used for Sitemap / search box).
+| `--google-analytics`  | Google Analytics tracking code to include in generated API docs.
+| `--debug`             | Turn on debug mode (prints verbose information from low-level parser). Useful when debugging / during development.
+| `--download`          | Pass this option to include a link to a generated ZIP archive in the API docs.
+| `--extensions`        | A list of scanned file extensions. **Multiple values are allowed**. Default: `["php"]`.
+| `--exclude`           | Diretories or files matching provided mask will be excluded (e.g. `*/tests/*`). **Multiple values are allowed**.
+| `--groups`            | Define element grouping in the menu [options: `namespaces`, `packages`]. Default: `namespaces`.
+| `--main`              | Elements with provided main name prefix will be first in the tree.
+| `--internal`          | Include elements marked as `@internal`.
+| `--php`               | Generate documentation for PHP internal classes.
+| `--no-source-code`    | Do not generate highlighted source code for elements.
+| `--template-theme`    | ApiGen template theme name. [default: "default"].
+| `--template-config`   | Specify your own template config (this setting will override `--template-theme`).
+| `--title`             | Custom title of API docs.
+| `--tree`              | Generate a tree view of classes, interfaces, traits and exceptions.
+| `--deprecated`        | deprecated, only present for BC
+| `--todo`              | deprecated, only present for BC
+| `--charset`           | deprecated, only present for BC
+| `--skip-doc-path`     | deprecated, only present for BC
+| `--overwrite` (`-o`)  | Force overwriting of destination directory.
+| `--help` (`-h`)       | Display help message for all or specific commands.
+| `--quiet` (`-q`)      | Do not output any messages.
+| `--version` (`-V`)    | Display version of apigen.
+| --------------------- |
+## Contributing
+
+Please refer to [CONTRIBUTING](CONTRIBUTING.md) for details.
+
+### Tests
+
+To run tests:
 
 ```sh
 $ vendor/bin/phpunit
@@ -65,11 +128,6 @@ $ vendor/bin/phpunit
 ## Get Support!
 
 * [#apigen](http://webchat.freenode.net/?channels=#apigen) on irc.freenode.net - Come chat with us, we have cake.
-
 * [GitHub Issues](https://github.com/ApiGen/ApiGen/issues) - Got issues? Please tell us!
-
 * [Roadmaps](https://github.com/ApiGen/ApiGen/wiki/Roadmaps) - Want to contribute? Get involved!
 
-## Contributing
-
-Please refer to [CONTRIBUTING](https://github.com/apigen/apigen/blob/master/CONTRIBUTING.md) for details.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ destination: docs       # destination directory to generate API docs in
 **Note!** The configuration files match CLI options for [generate](#generate)
 command. The only difference is that when defining these options in
 configuration file, you have to use `camelCased` format (i.e.
-`--annotation-groups` CLI options becomes `annotationGroups` configuration
+`--annotation-groups` CLI option becomes `annotationGroups` configuration
 parameter).
 
 #### Reference Configuration

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ A list of options accepted by `generate` command:
 | `--destination` (`-d`)| Destination directory for API docs.
 | `--access-levels`     | Access levels of methods and properties to be included in API docs [options: `public`, `protected`, `private`]. Default: `["public","protected"]`.
 | `--annotation-groups` | Generate page with elements with specific annotation.
-| `--config`            | Custom path to apigen configuration file. Default: `./apigen.neon`
+| `--config`            | Custom path to ApiGen configuration file. Default: `./apigen.neon`
 | `--google-cse-id`     | Custom Google Search Engine ID (for search box).
 | `--base-url`          | Base URL (used for Sitemap / search box).
 | `--google-analytics`  | Google Analytics tracking code to include in generated API docs.
@@ -172,8 +172,9 @@ A list of options accepted by `generate` command:
 | `--overwrite` (`-o`)  | Force overwriting of destination directory.
 | `--help` (`-h`)       | Display help message for all or specific commands.
 | `--quiet` (`-q`)      | Do not output any messages.
-| `--version` (`-V`)    | Display version of apigen.
+| `--version` (`-V`)    | Display version of ApiGen.
 | --------------------- |
+
 ## Contributing
 
 Please refer to [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ A list of options accepted by `generate` command:
 | `--version` (`-V`)    | Display version of ApiGen.
 | --------------------- |
 
+### Themes
+
+In order to enable a custom theme, you have to either provide `--theme-config`
+CLI option when runing `apigen generate` or add `themeConfig` configuration
+option in your ApiGen configuration file:
+
+```neon
+themeConfig: path/to/theme/config.neon # path to theme's config file
+```
+
 ## Contributing
 
 Please refer to [CONTRIBUTING](CONTRIBUTING.md) for details.

--- a/README.md
+++ b/README.md
@@ -85,38 +85,39 @@ configuration options, together with their default values.
 # and supported configuration options, together with their default values.
 # source options
 source: [src]                       # Source directory(-ies) to build API docs for
-extensions: [php] # array           # A list of file extension to include when
-                                    # scanning source dir
+                                    # (array)
+extensions: [php]                   # A list of file extension to include when
+                                    # scanning source dir (array)
 accessLevels: [public, protected]   # Access levels of methods and properties
-                                    # to include
-annotationGroups: [todo, deprecated]# Annotation Groups to include
+                                    # to include (array)
+annotationGroups: [todo, deprecated]# Annotation Groups to include (array)
 internal: false                     # Set to `true` to include @internal in API
-                                    # docs.
+                                    # docs (boolean)
 #main: 'SomePrefix'                 # Elements with this name prefix will be
-                                    # first in the tree.
+                                    # first in the tree (string)
 php: false                          # Set to `true` to generate docs for PHP
-                                    # internal classes.
+                                    # internal classes (boolean)
 noSourceCode: false                 # Set to `true` to NOT generate highlighted
-                                    # source code for elements.
+                                    # source code for elements (boolean)
 
 # destination / generated docs options
-destination: doc                    # Destination directory for API docs
+destination: doc                    # Destination directory for API docs (string)
 exclude: tests                      # A blob pattern to exclude from API docs
-                                    # generation.
-overwrite: true # bool              # Overwrite destination directory by
-                                    # default
-title: "ApiGen Docs"                # Title of generated API docs.
-baseUrl: http://apigen.org/api      # Base URL for generated API docs.
-templateConfig: path/to/config.neon # path to template configuration
+                                    # generation (string (blob))
+overwrite: true                     # Overwrite destination directory by
+                                    # default (boolean)
+title: "ApiGen Docs"                # Title of generated API docs (string)
+baseUrl: http://apigen.org/api      # Base URL for generated API docs (string (URL))
+templateConfig: path/to/config.neon # path to template configuration (string (path))
 
 # templates parameters
-googleAnalytics: 123
-googleCseId: 456
+googleAnalytics: 123                # Google Analytics tracking code (string)
+googleCseId: 456                    # Google Custom Search Engine ID (string)
 download: true                      # show a link to download API docs ZIP
-                                    # archive in the API docs
+                                    # archive in the API docs (boolean)
 
 # debug
-debug: false                        # set to true to enable debug
+debug: false                        # set to true to enable debug (boolean)
 ```
 
 ### CLI Commands


### PR DESCRIPTION
This PR adds Documentation section in README with the following subsections:
- `Configuration` - contains minimal configuration and reference configuration (with all configuration options).
- `CLI Commands` contains information on available commands (`generate` command) and all of the available CLI options with their description.

Minor tweaks to README.md for docs.

Preview of README.md at https://github.com/ApiGen/ApiGen/tree/config-and-cli-options

This should also fix #759 