### PR TITLE
Windows compatibility (filesystem + unit tests) + Appveyor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@
 .gitignore export-ignore
 .scrutinizer.yml export-ignore
 .travis.yml export-ignore
+appveyor.yml export-ignore
 CONTRIBUTING.md export-ignore
 phpunit.xml.dist export-ignore
 tests/ export-ignore

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -6,8 +6,8 @@ before_commands:
     - "composer install --prefer-source"
 
 tools:
-    external_code_coverage:
-        timeout: 900
+    external_code_coverage: false
+        #timeout: 900
     sensiolabs_security_checker: true
     php_code_coverage:
         enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   destination directory when building docs [#604].
 - Added `.editorconfig` to the project.
 - Enabled PHP7 tests in Travis-CI.
+- Enabled automated CI tests on Windows via Appveyor [#831]
 - Added `--debug` CLI option, which prints detailed parser errors.
 - Added `--overwrite` CLI option [#679].
 - Added support for `static` type [#704].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed an issue with temporary files not being removed upon exit (in cases
   where failure happens) [#520]
 - Fixed an issue with `generate` command throwing an error [#631]
+- Fixed tests (and hopefully compatibility) on Windows OS [#804]
 - Fixed deprecation checks when generating docs
 - Fixed issues with exception handling in low-level parser
 - Fixed generation problems when generating docs for classes using same Traits.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Smart and Readable Documentation for your PHP project
 
 [![Build Status](https://img.shields.io/travis/ApiGen/ApiGen/master.svg?style=flat-square)](https://travis-ci.org/ApiGen/ApiGen)
+[![Build status](https://ci.appveyor.com/api/projects/status/p8y6685thhh7mgw0/branch/4.2?svg=true)](https://ci.appveyor.com/project/ek9/apigen/branch/4.2)
 [![Quality Score](https://img.shields.io/scrutinizer/g/ApiGen/ApiGen.svg?style=flat-square)](https://scrutinizer-ci.com/g/ApiGen/ApiGen)
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/ApiGen/ApiGen.svg?style=flat-square)](https://scrutinizer-ci.com/g/ApiGen/ApiGen)
 [![Downloads](https://img.shields.io/packagist/dt/apigen/apigen.svg?style=flat-square)](https://packagist.org/packages/apigen/apigen)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,6 @@ shallow_clone: false
 platform: x64
 clone_folder: c:\projects\apigen
 
-environment:
-  matrix:
-  - PHP_DOWNLOAD_FILE: php-7.1.3-nts-Win32-VC14-x64.zip
-
 skip_commits:
   message: /\[ci skip\]/
 
@@ -25,8 +21,8 @@ init:
 install:
   - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
   - cd c:\php
-  - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/%PHP_DOWNLOAD_FILE%
-  - IF %PHP%==1 7z x %PHP_DOWNLOAD_FILE% -y > 7z.log
+  - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-7.1.3-nts-Win32-VC14-x64.zip
+  - IF %PHP%==1 7z x php-7.1.3-nts-Win32-VC14-x64.zip -y > 7z.log
   - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
   - appveyor DownloadFile https://getcomposer.org/composer.phar
   - copy php.ini-production php.ini /Y

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,8 +21,8 @@ init:
 install:
   - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
   - cd c:\php
-  - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-7.1.3-nts-Win32-VC14-x64.zip
-  - IF %PHP%==1 7z x php-7.1.3-nts-Win32-VC14-x64.zip -y > 7z.log
+  - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-7.1.2-nts-Win32-VC14-x64.zip
+  - IF %PHP%==1 7z x php-7.1.2-nts-Win32-VC14-x64.zip -y > 7z.log
   - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
   - appveyor DownloadFile https://getcomposer.org/composer.phar
   - copy php.ini-production php.ini /Y

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,19 +19,21 @@ init:
   - git config --global core.autocrlf input
 
 install:
+  # install php 7.1.2
   - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
   - cd c:\php
   - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-7.1.2-nts-Win32-VC14-x64.zip
   - IF %PHP%==1 7z x php-7.1.2-nts-Win32-VC14-x64.zip -y > 7z.log
   - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
   - appveyor DownloadFile https://getcomposer.org/composer.phar
+  # setup PHP config (php.ini)
   - copy php.ini-production php.ini /Y
   - echo date.timezone="UTC" >> php.ini
+  # enable composer specific extensions
   - echo extension_dir=ext >> php.ini
   - echo extension=php_openssl.dll >> php.ini
   - echo extension=php_curl.dll >> php.ini
-  - echo extension=php_mbstring.dll >> php.ini
-  - echo extension=php_fileinfo.dll >> php.ini
+  # cd to project dir and run composer install
   - cd c:\projects\apigen
   - composer install --no-progress --ansi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,4 +37,4 @@ install:
 
 test_script:
   - cd c:\projects\apigen
-  - php vendor\phpunit\phpunit\phpunit --testdox
+  - php vendor\phpunit\phpunit\phpunit -vvv

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,44 @@
+version: '{branch}-{build}'
+build: false
+shallow_clone: false
+platform: x64
+clone_folder: c:\projects\apigen
+
+environment:
+    matrix:
+        - PHP_DOWNLOAD_FILE: php-7.1.3-nts-Win32-VC14-x64.zip
+
+skip_commits:
+    message: /\[ci skip\]/
+
+cache:
+    - c:\php -> appveyor.yml
+	  - composer.phar
+
+init:
+    - SET PATH=c:\php;%PATH%
+    - SET COMPOSER_NO_INTERACTION=1
+    - SET PHP=1
+    - SET ANSICON=121x90 (121x90)
+    - git config --global core.autocrlf input
+
+install:
+    - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
+    - cd c:\php
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/%PHP_DOWNLOAD_FILE%
+    - IF %PHP%==1 7z x %PHP_DOWNLOAD_FILE% -y > 7z.log
+    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+    - appveyor DownloadFile https://getcomposer.org/composer.phar
+    - copy php.ini-production php.ini /Y
+    - echo date.timezone="UTC" >> php.ini
+    - echo extension_dir=ext >> php.ini
+    - echo extension=php_openssl.dll >> php.ini
+    - echo extension=php_curl.dll >> php.ini
+    - echo extension=php_mbstring.dll >> php.ini
+    - echo extension=php_fileinfo.dll >> php.ini
+    - cd c:\projects\apigen
+    - composer install --no-progress --ansi
+
+test_script:
+    - cd c:\projects\apigen
+    - php vendor\phpunit\phpunit\phpunit --testdox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,40 +5,40 @@ platform: x64
 clone_folder: c:\projects\apigen
 
 environment:
-    matrix:
-        - PHP_DOWNLOAD_FILE: php-7.1.3-nts-Win32-VC14-x64.zip
+  matrix:
+    - PHP_DOWNLOAD_FILE: php-7.1.3-nts-Win32-VC14-x64.zip
 
 skip_commits:
-    message: /\[ci skip\]/
+  message: /\[ci skip\]/
 
 cache:
-    - c:\php -> appveyor.yml
-	  - composer.phar
+  - c:\php -> appveyor.yml
+  - composer.phar
 
 init:
-    - SET PATH=c:\php;%PATH%
-    - SET COMPOSER_NO_INTERACTION=1
-    - SET PHP=1
-    - SET ANSICON=121x90 (121x90)
-    - git config --global core.autocrlf input
+  - SET PATH=c:\php;%PATH%
+  - SET COMPOSER_NO_INTERACTION=1
+  - SET PHP=1
+  - SET ANSICON=121x90 (121x90)
+  - git config --global core.autocrlf input
 
 install:
-    - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
-    - cd c:\php
-    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/%PHP_DOWNLOAD_FILE%
-    - IF %PHP%==1 7z x %PHP_DOWNLOAD_FILE% -y > 7z.log
-    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
-    - appveyor DownloadFile https://getcomposer.org/composer.phar
-    - copy php.ini-production php.ini /Y
-    - echo date.timezone="UTC" >> php.ini
-    - echo extension_dir=ext >> php.ini
-    - echo extension=php_openssl.dll >> php.ini
-    - echo extension=php_curl.dll >> php.ini
-    - echo extension=php_mbstring.dll >> php.ini
-    - echo extension=php_fileinfo.dll >> php.ini
-    - cd c:\projects\apigen
-    - composer install --no-progress --ansi
+  - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
+  - cd c:\php
+  - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/%PHP_DOWNLOAD_FILE%
+  - IF %PHP%==1 7z x %PHP_DOWNLOAD_FILE% -y > 7z.log
+  - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+  - appveyor DownloadFile https://getcomposer.org/composer.phar
+  - copy php.ini-production php.ini /Y
+  - echo date.timezone="UTC" >> php.ini
+  - echo extension_dir=ext >> php.ini
+  - echo extension=php_openssl.dll >> php.ini
+  - echo extension=php_curl.dll >> php.ini
+  - echo extension=php_mbstring.dll >> php.ini
+  - echo extension=php_fileinfo.dll >> php.ini
+  - cd c:\projects\apigen
+  - composer install --no-progress --ansi
 
 test_script:
-    - cd c:\projects\apigen
-    - php vendor\phpunit\phpunit\phpunit --testdox
+  - cd c:\projects\apigen
+  - php vendor\phpunit\phpunit\phpunit --testdox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ clone_folder: c:\projects\apigen
 
 environment:
   matrix:
-    - PHP_DOWNLOAD_FILE: php-7.1.3-nts-Win32-VC14-x64.zip
+  - PHP_DOWNLOAD_FILE: php-7.1.3-nts-Win32-VC14-x64.zip
 
 skip_commits:
   message: /\[ci skip\]/

--- a/src/Console/Command/GenerateCommand.php
+++ b/src/Console/Command/GenerateCommand.php
@@ -234,7 +234,6 @@ class GenerateCommand extends AbstractCommand
             $this->generate($options);
             return 0;
         } catch (\Exception $e) {
-            var_dump($e->getMessage());
             $output->writeln(
                 sprintf(PHP_EOL . '<error>%s</error>', $e->getMessage())
             );

--- a/src/Console/Command/GenerateCommand.php
+++ b/src/Console/Command/GenerateCommand.php
@@ -234,6 +234,7 @@ class GenerateCommand extends AbstractCommand
             $this->generate($options);
             return 0;
         } catch (\Exception $e) {
+            var_dump($e->getMessage());
             $output->writeln(
                 sprintf(PHP_EOL . '<error>%s</error>', $e->getMessage())
             );

--- a/src/Generator/Resolvers/RelativePathResolver.php
+++ b/src/Generator/Resolvers/RelativePathResolver.php
@@ -62,7 +62,7 @@ class RelativePathResolver
     {
         $directory = $this->fileSystem->normalizePath($directory);
         $fileName = $this->fileSystem->normalizePath($fileName);
-        $directory = rtrim($directory, '/');
+        $directory = rtrim($directory, DIRECTORY_SEPARATOR);
         return substr($fileName, strlen($directory) + 1);
     }
 }

--- a/src/Templating/TemplateNavigator.php
+++ b/src/Templating/TemplateNavigator.php
@@ -75,7 +75,7 @@ class TemplateNavigator
     public function getTemplateFileName($name)
     {
         $options = $this->configuration->getOptions();
-        return $this->getDestination() . '/' . $options[CO::TEMPLATE][TCO::TEMPLATES][$name]['filename'];
+        return $this->getDestination() . DIRECTORY_SEPARATOR . $options[CO::TEMPLATE][TCO::TEMPLATES][$name]['filename'];
     }
 
 
@@ -85,7 +85,7 @@ class TemplateNavigator
      */
     public function getTemplatePathForNamespace($namespace)
     {
-        return $this->getDestination() . '/' . $this->namespaceAndPackageUrlFilters->namespaceUrl($namespace);
+        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->namespaceAndPackageUrlFilters->namespaceUrl($namespace);
     }
 
 
@@ -95,7 +95,7 @@ class TemplateNavigator
      */
     public function getTemplatePathForPackage($package)
     {
-        return $this->getDestination() . '/' . $this->namespaceAndPackageUrlFilters->packageUrl($package);
+        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->namespaceAndPackageUrlFilters->packageUrl($package);
     }
 
 
@@ -104,7 +104,7 @@ class TemplateNavigator
      */
     public function getTemplatePathForClass(ClassReflectionInterface $element)
     {
-        return $this->getDestination() . '/' . $this->elementUrlFactory->createForClass($element);
+        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->elementUrlFactory->createForClass($element);
     }
 
 
@@ -113,7 +113,7 @@ class TemplateNavigator
      */
     public function getTemplatePathForConstant(ConstantReflectionInterface $element)
     {
-        return $this->getDestination() . '/' . $this->elementUrlFactory->createForConstant($element);
+        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->elementUrlFactory->createForConstant($element);
     }
 
 
@@ -122,7 +122,7 @@ class TemplateNavigator
      */
     public function getTemplatePathForFunction(FunctionReflectionInterface $element)
     {
-        return $this->getDestination() . '/' . $this->elementUrlFactory->createForFunction($element);
+        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->elementUrlFactory->createForFunction($element);
     }
 
 
@@ -131,7 +131,7 @@ class TemplateNavigator
      */
     public function getTemplatePathForSourceElement(ElementReflectionInterface $element)
     {
-        return $this->getDestination() . '/' . $this->sourceFilters->sourceUrl($element, false);
+        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->sourceFilters->sourceUrl($element, false);
     }
 
 
@@ -141,7 +141,7 @@ class TemplateNavigator
      */
     public function getTemplatePathForAnnotationGroup($element)
     {
-        return $this->getDestination() . '/' . $this->elementUrlFactory->createForAnnotationGroup($element);
+        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->elementUrlFactory->createForAnnotationGroup($element);
     }
 
 

--- a/src/Templating/TemplateNavigator.php
+++ b/src/Templating/TemplateNavigator.php
@@ -75,7 +75,8 @@ class TemplateNavigator
     public function getTemplateFileName($name)
     {
         $options = $this->configuration->getOptions();
-        return $this->getDestination() . DIRECTORY_SEPARATOR . $options[CO::TEMPLATE][TCO::TEMPLATES][$name]['filename'];
+        return $this->getDestination() . DIRECTORY_SEPARATOR
+            . $options[CO::TEMPLATE][TCO::TEMPLATES][$name]['filename'];
     }
 
 
@@ -85,7 +86,8 @@ class TemplateNavigator
      */
     public function getTemplatePathForNamespace($namespace)
     {
-        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->namespaceAndPackageUrlFilters->namespaceUrl($namespace);
+        return $this->getDestination() . DIRECTORY_SEPARATOR
+            . $this->namespaceAndPackageUrlFilters->namespaceUrl($namespace);
     }
 
 
@@ -95,7 +97,8 @@ class TemplateNavigator
      */
     public function getTemplatePathForPackage($package)
     {
-        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->namespaceAndPackageUrlFilters->packageUrl($package);
+        return $this->getDestination() . DIRECTORY_SEPARATOR
+            . $this->namespaceAndPackageUrlFilters->packageUrl($package);
     }
 
 
@@ -104,7 +107,8 @@ class TemplateNavigator
      */
     public function getTemplatePathForClass(ClassReflectionInterface $element)
     {
-        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->elementUrlFactory->createForClass($element);
+        return $this->getDestination() . DIRECTORY_SEPARATOR
+            . $this->elementUrlFactory->createForClass($element);
     }
 
 
@@ -113,7 +117,8 @@ class TemplateNavigator
      */
     public function getTemplatePathForConstant(ConstantReflectionInterface $element)
     {
-        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->elementUrlFactory->createForConstant($element);
+        return $this->getDestination() . DIRECTORY_SEPARATOR
+            . $this->elementUrlFactory->createForConstant($element);
     }
 
 
@@ -122,7 +127,8 @@ class TemplateNavigator
      */
     public function getTemplatePathForFunction(FunctionReflectionInterface $element)
     {
-        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->elementUrlFactory->createForFunction($element);
+        return $this->getDestination() . DIRECTORY_SEPARATOR
+            . $this->elementUrlFactory->createForFunction($element);
     }
 
 
@@ -131,7 +137,8 @@ class TemplateNavigator
      */
     public function getTemplatePathForSourceElement(ElementReflectionInterface $element)
     {
-        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->sourceFilters->sourceUrl($element, false);
+        return $this->getDestination() . DIRECTORY_SEPARATOR
+            . $this->sourceFilters->sourceUrl($element, false);
     }
 
 
@@ -141,7 +148,8 @@ class TemplateNavigator
      */
     public function getTemplatePathForAnnotationGroup($element)
     {
-        return $this->getDestination() . DIRECTORY_SEPARATOR . $this->elementUrlFactory->createForAnnotationGroup($element);
+        return $this->getDestination() . DIRECTORY_SEPARATOR
+            . $this->elementUrlFactory->createForAnnotationGroup($element);
     }
 
 

--- a/src/Theme/ThemeConfigPathResolver.php
+++ b/src/Theme/ThemeConfigPathResolver.php
@@ -38,11 +38,11 @@ class ThemeConfigPathResolver
     {
         $allowedPaths = [
             $this->rootDir,
-            $this->rootDir . '/../../..'
+            $this->rootDir . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..'
         ];
 
         foreach ($allowedPaths as $allowedPath) {
-            $absolutePath = $allowedPath . '/' . ltrim($path, '/');
+            $absolutePath = $allowedPath . DIRECTORY_SEPARATOR . ltrim($path, DIRECTORY_SEPARATOR);
             if (file_exists($absolutePath)) {
                 return $absolutePath;
             }

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -20,7 +20,7 @@ class FileSystem
      */
     public function normalizePath($path)
     {
-        return str_replace('\\', '/', $path);
+        return str_replace(['\\', '/'], DIRECTORY_SEPARATOR, $path);
     }
 
 

--- a/src/Utils/Neon/NeonFile.php
+++ b/src/Utils/Neon/NeonFile.php
@@ -38,7 +38,7 @@ class NeonFile
      */
     private function validatePath($path)
     {
-        if (! file_exists($path)) {
+        if (! file_exists($path) || ! is_file($path)) {
             throw new MissingFileException($path . ' could not be found');
         }
 

--- a/tests/Console/Command/GenerateCommandPrepareOptionsTest.php
+++ b/tests/Console/Command/GenerateCommandPrepareOptionsTest.php
@@ -37,7 +37,7 @@ class GenerateCommandPrepareOptionsTest extends ContainerAwareTestCase
         $this->setExpectedException(ConfigurationException::class, 'Source is not set');
         MethodInvoker::callMethodOnObject($this->generateCommand, 'prepareOptions', [[
             'config' => '...',
-            'destination' => TEMP_DIR . '/api'
+            'destination' => TEMP_DIR . DIRECTORY_SEPARATOR . 'api'
         ]]);
     }
 
@@ -46,19 +46,19 @@ class GenerateCommandPrepareOptionsTest extends ContainerAwareTestCase
     {
         $options = MethodInvoker::callMethodOnObject($this->generateCommand, 'prepareOptions', [[
             'config' => '...',
-            'destination' => TEMP_DIR . '/api',
+            'destination' => TEMP_DIR . DIRECTORY_SEPARATOR . 'api',
             'source' => __DIR__
         ]]);
 
-        $this->assertSame(TEMP_DIR . '/api', $options['destination']);
+        $this->assertSame(TEMP_DIR . DIRECTORY_SEPARATOR . 'api', $options['destination']);
     }
 
 
     public function testPrepareOptionsConfigPriority()
     {
         $configAndDestinationOptions = [
-            'config' => __DIR__ . '/apigen.neon',
-            'destination' => TEMP_DIR . '/api',
+            'config' => __DIR__ . DIRECTORY_SEPARATOR . 'apigen.neon',
+            'destination' => TEMP_DIR . DIRECTORY_SEPARATOR . 'api',
             'source' => __DIR__
         ];
 
@@ -72,8 +72,8 @@ class GenerateCommandPrepareOptionsTest extends ContainerAwareTestCase
     public function testPrepareOptionsMergeIsCorrect()
     {
         $options = MethodInvoker::callMethodOnObject($this->generateCommand, 'prepareOptions', [[
-            'config' => __DIR__ . '/apigen.neon',
-            'destination' => TEMP_DIR . '/api',
+            'config' => __DIR__ . DIRECTORY_SEPARATOR . 'apigen.neon',
+            'destination' => TEMP_DIR . DIRECTORY_SEPARATOR . 'api',
             'download' => false
         ]]);
 
@@ -88,14 +88,14 @@ class GenerateCommandPrepareOptionsTest extends ContainerAwareTestCase
     public function testPrepareOptionsMergeIsCorrectFromYamlConfig()
     {
         $optionsYaml = MethodInvoker::callMethodOnObject($this->generateCommand, 'prepareOptions', [[
-            'config' => __DIR__ . '/apigen.yml',
-            'destination' => TEMP_DIR . '/api',
+            'config' => __DIR__ . DIRECTORY_SEPARATOR . 'apigen.yml',
+            'destination' => TEMP_DIR . DIRECTORY_SEPARATOR . 'api',
             'download' => false
         ]]);
 
         $optionsNeon = MethodInvoker::callMethodOnObject($this->generateCommand, 'prepareOptions', [[
-            'config' => __DIR__ . '/apigen.neon',
-            'destination' => TEMP_DIR . '/api',
+            'config' => __DIR__ . DIRECTORY_SEPARATOR . 'apigen.neon',
+            'destination' => TEMP_DIR . DIRECTORY_SEPARATOR . 'api',
             'download' => false
         ]]);
 
@@ -106,7 +106,7 @@ class GenerateCommandPrepareOptionsTest extends ContainerAwareTestCase
     public function testLoadOptionsFromConfig()
     {
         $options['config'] = '...';
-        file_put_contents(getcwd() . '/apigen.neon.dist', 'debug: true');
+        file_put_contents(getcwd() . DIRECTORY_SEPARATOR . 'apigen.neon.dist', 'debug: true');
 
         $options = MethodInvoker::callMethodOnObject($this->generateCommand, 'loadOptionsFromConfig', [$options]);
         $this->assertSame([
@@ -114,6 +114,6 @@ class GenerateCommandPrepareOptionsTest extends ContainerAwareTestCase
             'debug' => true
         ], $options);
 
-        unlink(getcwd() . '/apigen.neon.dist');
+        unlink(getcwd() . DIRECTORY_SEPARATOR . 'apigen.neon.dist');
     }
 }

--- a/tests/Generator/Resolvers/RelativePathResolverTest.php
+++ b/tests/Generator/Resolvers/RelativePathResolverTest.php
@@ -34,7 +34,7 @@ class RelativePathResolverTest extends PHPUnit_Framework_TestCase
         $relativePathResolver = new RelativePathResolver($configuration, new FileSystem);
 
         $this->assertSame('file.txt', $relativePathResolver->getRelativePath('C:\some\dir\file.txt'));
-        $this->assertSame('more-dir\file.txt', $relativePathResolver->getRelativePath('C:\some\dir\more-dir\file.txt'));
+        $this->assertSame('more-dir'.DIRECTORY_SEPARATOR.'file.txt', $relativePathResolver->getRelativePath('C:\some\dir\more-dir\file.txt'));
     }
 
 

--- a/tests/Generator/Resolvers/RelativePathResolverTest.php
+++ b/tests/Generator/Resolvers/RelativePathResolverTest.php
@@ -34,7 +34,7 @@ class RelativePathResolverTest extends PHPUnit_Framework_TestCase
         $relativePathResolver = new RelativePathResolver($configuration, new FileSystem);
 
         $this->assertSame('file.txt', $relativePathResolver->getRelativePath('C:\some\dir\file.txt'));
-        $this->assertSame('more-dir/file.txt', $relativePathResolver->getRelativePath('C:\some\dir\more-dir\file.txt'));
+        $this->assertSame('more-dir\file.txt', $relativePathResolver->getRelativePath('C:\some\dir\more-dir\file.txt'));
     }
 
 
@@ -60,9 +60,9 @@ class RelativePathResolverTest extends PHPUnit_Framework_TestCase
         $relativePathResolver = new RelativePathResolver($configuration, new FileSystem);
 
         $fileName = 'ProjectBeta/entities/Category.php';
-        $this->assertSame('entities/Category.php', $relativePathResolver->getRelativePath($fileName));
+        $this->assertSame('entities'.DIRECTORY_SEPARATOR.'Category.php', $relativePathResolver->getRelativePath($fileName));
 
         $fileName = 'ProjectBeta/entities/Category.php';
-        $this->assertSame('entities/Category.php', $relativePathResolver->getRelativePath($fileName));
+        $this->assertSame('entities'.DIRECTORY_SEPARATOR.'Category.php', $relativePathResolver->getRelativePath($fileName));
     }
 }

--- a/tests/Generator/Resolvers/RelativePathResolverTest.php
+++ b/tests/Generator/Resolvers/RelativePathResolverTest.php
@@ -18,10 +18,11 @@ class RelativePathResolverTest extends PHPUnit_Framework_TestCase
         $configuration->shouldReceive('getOption')->with('source')->andReturn([TEMP_DIR]);
         $relativePathResolver = new RelativePathResolver($configuration, new FileSystem);
 
+        $testData = 'dir' . DIRECTORY_SEPARATOR . 'some-file.txt';
         $this->assertSame('some-file.txt', $relativePathResolver->getRelativePath(TEMP_DIR . '/some-file.txt'));
         $this->assertSame(
-            'some/dir/some-file.txt',
-            $relativePathResolver->getRelativePath(TEMP_DIR . '/some/dir/some-file.txt')
+            $testData,
+            $relativePathResolver->getRelativePath(TEMP_DIR . DIRECTORY_SEPARATOR . $testData)
         );
     }
 

--- a/tests/Templating/TemplateNavigatorTest.php
+++ b/tests/Templating/TemplateNavigatorTest.php
@@ -75,7 +75,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
     public function testGetTemplateFileName()
     {
         $this->assertSame(
-            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/index.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR . DIRECTORY_SEPARATOR . 'api' . DIRECTORY_SEPARATOR . 'index.html'),
             $this->templateNavigator->getTemplateFileName('overview')
         );
     }
@@ -93,7 +93,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
     public function testGetTemplatePathForNamespace()
     {
         $this->assertSame(
-            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/namespace-MyNamespace.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR . DIRECTORY_SEPARATOR . 'api' . DIRECTORY_SEPARATOR . 'namespace-MyNamespace.html'),
             $this->templateNavigator->getTemplatePathForNamespace('MyNamespace')
         );
     }
@@ -102,7 +102,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
     public function testGetTemplatePathForPackage()
     {
         $this->assertSame(
-            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/package-MyPackage.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR . DIRECTORY_SEPARATOR . 'api' . DIRECTORY_SEPARATOR . 'package-MyPackage.html'),
             $this->templateNavigator->getTemplatePathForPackage('MyPackage')
         );
     }
@@ -114,7 +114,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
         $classReflectionMock->shouldReceive('getName')->andReturn('SomeClass');
 
         $this->assertSame(
-            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/class-SomeClass.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR . DIRECTORY_SEPARATOR . 'api' . DIRECTORY_SEPARATOR . 'class-SomeClass.html'),
             $this->templateNavigator->getTemplatePathForClass($classReflectionMock)
         );
     }
@@ -126,7 +126,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
         $constantReflectionMock->shouldReceive('getName')->andReturn('SomeConstant');
 
         $this->assertSame(
-            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/constant-SomeConstant.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR . DIRECTORY_SEPARATOR . 'api' . DIRECTORY_SEPARATOR . 'constant-SomeConstant.html'),
             $this->templateNavigator->getTemplatePathForConstant($constantReflectionMock)
         );
     }
@@ -138,7 +138,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
         $functionReflectionMock->shouldReceive('getName')->andReturn('SomeFunction');
 
         $this->assertSame(
-            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/function-SomeFunction.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR .DIRECTORY_SEPARATOR .  'api' . DIRECTORY_SEPARATOR . 'function-SomeFunction.html'),
             $this->templateNavigator->getTemplatePathForFunction($functionReflectionMock)
         );
     }
@@ -150,7 +150,7 @@ class TemplateNavigatorTest extends ContainerAwareTestCase
         $classReflectionMock->shouldReceive('getName')->andReturn('SomeClass');
 
         $this->assertSame(
-            $this->fileSystem->getAbsolutePath(TEMP_DIR . '/api/source-code-SomeClass.html'),
+            $this->fileSystem->getAbsolutePath(TEMP_DIR . DIRECTORY_SEPARATOR . 'api' . DIRECTORY_SEPARATOR . 'source-code-SomeClass.html'),
             $this->templateNavigator->getTemplatePathForSourceElement($classReflectionMock)
         );
     }

--- a/tests/Theme/ThemeConfigPathResolverTest.php
+++ b/tests/Theme/ThemeConfigPathResolverTest.php
@@ -14,9 +14,13 @@ class ThemeConfigPathResolverTest extends PHPUnit_Framework_TestCase
         $themeConfigPathResolver = new ThemeConfigPathResolver(__DIR__ . '/ThemeConfigPathResolverSource');
 
         $configPath = $themeConfigPathResolver->resolve('/config.neon');
-        $this->assertSame(__DIR__  . '/ThemeConfigPathResolverSource/config.neon', $configPath);
+        $this->assertSame(
+            __DIR__  . DIRECTORY_SEPARATOR . 'ThemeConfigPathResolverSource' . DIRECTORY_SEPARATOR . 'config.neon',
+            $configPath);
 
         $configPath = $themeConfigPathResolver->resolve('config.neon');
-        $this->assertSame(__DIR__  . '/ThemeConfigPathResolverSource/config.neon', $configPath);
+        $this->assertSame(
+            __DIR__  . DIRECTORY_SEPARATOR . 'ThemeConfigPathResolverSource' . DIRECTORY_SEPARATOR . 'config.neon',
+            $configPath);
     }
 }

--- a/tests/Theme/ThemeConfigPathResolverTest.php
+++ b/tests/Theme/ThemeConfigPathResolverTest.php
@@ -11,9 +11,10 @@ class ThemeConfigPathResolverTest extends PHPUnit_Framework_TestCase
 
     public function testResolve()
     {
-        $themeConfigPathResolver = new ThemeConfigPathResolver(__DIR__ . '/ThemeConfigPathResolverSource');
+        $themeConfigPathResolver =
+            new ThemeConfigPathResolver(__DIR__ . DIRECTORY_SEPARATOR . 'ThemeConfigPathResolverSource');
 
-        $configPath = $themeConfigPathResolver->resolve('/config.neon');
+        $configPath = $themeConfigPathResolver->resolve(DIRECTORY_SEPARATOR . 'config.neon');
         $this->assertSame(
             __DIR__  . DIRECTORY_SEPARATOR . 'ThemeConfigPathResolverSource' . DIRECTORY_SEPARATOR . 'config.neon',
             $configPath);

--- a/tests/Utils/FileSystemTest.php
+++ b/tests/Utils/FileSystemTest.php
@@ -23,8 +23,8 @@ class FileSystemTest extends PHPUnit_Framework_TestCase
 
     public function testNormalizePath()
     {
-        $backslashPath = 'C:\User\Program File\ApiGen';
-        $this->assertSame('C:/User/Program File/ApiGen', $this->fileSystem->normalizePath($backslashPath));
+        $backslashPath = 'C:' . DIRECTORY_SEPARATOR . 'User' . DIRECTORY_SEPARATOR . 'Program Fil' . DIRECTORY_SEPARATOR . '\ApiGen';
+        $this->assertSame($backslashPath, $this->fileSystem->normalizePath($backslashPath));
     }
 
 
@@ -84,12 +84,12 @@ class FileSystemTest extends PHPUnit_Framework_TestCase
         mkdir($absoluteDir);
         $this->assertTrue(file_exists($absoluteDir));
 
-        $absoluteFile = $absoluteDir . '/file.txt';
+        $absoluteFile = $absoluteDir . DIRECTORY_SEPARATOR . 'file.txt';
         file_put_contents($absoluteFile, '...');
         $this->assertTrue(file_exists($absoluteFile));
 
         $this->assertSame($absoluteDir, $this->fileSystem->getAbsolutePath($absoluteDir));
-        $this->assertSame($absoluteDir . '/file.txt', $this->fileSystem->getAbsolutePath('file.txt', [$absoluteDir]));
+        $this->assertSame($absoluteDir . DIRECTORY_SEPARATOR . 'file.txt', $this->fileSystem->getAbsolutePath('file.txt', [$absoluteDir]));
 
         $this->assertSame(
             'someFile.txt',

--- a/tests/Utils/FileSystemTest.php
+++ b/tests/Utils/FileSystemTest.php
@@ -23,7 +23,7 @@ class FileSystemTest extends PHPUnit_Framework_TestCase
 
     public function testNormalizePath()
     {
-        $backslashPath = 'C:' . DIRECTORY_SEPARATOR . 'User' . DIRECTORY_SEPARATOR . 'Program Fil' . DIRECTORY_SEPARATOR . '\ApiGen';
+        $backslashPath = 'C:' . DIRECTORY_SEPARATOR . 'Program Files' . DIRECTORY_SEPARATOR . 'ApiGen';
         $this->assertSame($backslashPath, $this->fileSystem->normalizePath($backslashPath));
     }
 
@@ -96,9 +96,10 @@ class FileSystemTest extends PHPUnit_Framework_TestCase
             $this->fileSystem->getAbsolutePath('someFile.txt')
         );
 
+        $testFile = DIRECTORY_SEPARATOR . 'someDir' . DIRECTORY_SEPARATOR . 'someDeeperFile.txt';
         $this->assertSame(
-            '/someDir/someDeeperFile.txt',
-            $this->fileSystem->getAbsolutePath('\someDir\someDeeperFile.txt')
+            $testFile,
+            $this->fileSystem->getAbsolutePath($testFile)
         );
     }
 


### PR DESCRIPTION
This PR updates ApiGen's Filesystem related classes + their unit tests to be OS agnostic. It mostly does so by relying on DIRECTORY_SEPARATOR variable instead of hardcoding unix-like (or in some cases windows-like) path.

Additionally, it adds `appveyor.yml` with Appveyor support (tested on https://ci.appveyor.com/project/ek9/apigen ). I was able to verify tests locally (on Linux) and on Windows (via Appveyor).

This PR additionally has commits from #828 

Fixes #804 #831 