### PR TITLE
Merge PHP5.6 Tests to master

### DIFF
--- a/tests/Parser/Broker/BackendSourcePhp56DefaultArguments/DefaultArguments.php
+++ b/tests/Parser/Broker/BackendSourcePhp56DefaultArguments/DefaultArguments.php
@@ -1,0 +1,24 @@
+<?php
+
+const GLOBAL_CONST = 1;
+
+
+abstract class SomeClass
+{
+
+    const CLASS_CONST = 2;
+
+}
+
+
+function classConst($agr1, $arg2 = SomeClass::CLASS_CONST)
+{
+
+}
+
+
+function globalConst($arg = GLOBAL_CONST)
+{
+
+}
+

--- a/tests/Parser/Broker/BackendSourcePhp56Namespaces/Namespaces.php
+++ b/tests/Parser/Broker/BackendSourcePhp56Namespaces/Namespaces.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace some\Name\space
+{
+
+    const SOME_CONSTANT = 2 * 3;
+
+
+    define('OTHER_CONSTANT', 2);
+
+
+    function someAloneFunction()
+    {
+
+    }
+
+
+    function someOtherFunction()
+    {
+
+    }
+
+}
+
+
+namespace some\Other\space
+{
+
+    use function \some\Name\space\someOtherFunction;
+    use function \some\Name\space\someAloneFunction as someFunction;
+    use const some\Name\space\SOME_CONSTANT;
+    use const some\Name\space\OTHER_CONSTANT as SECOND_NAME;
+
+
+    function someAloneFunction()
+    {
+        someFunction();
+        someOtherFunction();
+    }
+
+}
+

--- a/tests/Parser/Broker/BackendSourcePhp56VariadicFunctions/VariadicFunctions.php
+++ b/tests/Parser/Broker/BackendSourcePhp56VariadicFunctions/VariadicFunctions.php
@@ -1,0 +1,18 @@
+<?php
+
+function complexParameters($reqArg, $optArg = null, ...$variadicArgs)
+{
+
+}
+
+
+function simpleParameters(...$variadicArgs)
+{
+
+}
+
+
+function typehintedParameters(callable ...$variadicArgs)
+{
+
+}

--- a/tests/Parser/Broker/BackendTest.php
+++ b/tests/Parser/Broker/BackendTest.php
@@ -171,3 +171,4 @@ final class BackendTest extends TestCase
         return new ReflectionFactory($configurationMock, $parserStoragetMock);
     }
 }
+

--- a/tests/Parser/Broker/BackendTest.php
+++ b/tests/Parser/Broker/BackendTest.php
@@ -68,6 +68,59 @@ final class BackendTest extends TestCase
         $this->checkLoadedProperties($constant);
     }
 
+    public function testPhp56DefaultArguments(): void
+    {
+        $this->broker->processDirectory(__DIR__ . '/BackendSourcePhp56DefaultArguments');
+        $functions = $this->backend->getFunctions();
+        $this->assertCount(2, $functions);
+        foreach ($functions as $function) {
+            $this->assertInstanceOf('ApiGen\Reflection\ReflectionFunction', $function);
+            $this->checkLoadedProperties($function);
+        }
+        $constants = $this->backend->getConstants();
+        $this->assertCount(1, $constants);
+        foreach ($constants as $constant)
+        {
+            $this->assertInstanceOf('ApiGen\Reflection\ReflectionConstant', $constant);
+            $this->checkLoadedProperties($constant);
+        }
+        $classes = $this->backend->getClasses();
+        $this->assertCount(1, $classes);
+        foreach ($classes as $class)
+        {
+            $this->assertInstanceOf('ApiGen\Reflection\ReflectionConstant', $constant);
+            $this->checkLoadedProperties($constant);
+        }
+    }
+
+    public function testPhp56Namespaces(): void
+    {
+        $this->broker->processDirectory(__DIR__ . '/BackendSourcePhp56Namespaces');
+        $functions = $this->backend->getFunctions();
+        $this->assertCount(3, $functions);
+        foreach ($functions as $function) {
+            $this->assertInstanceOf('ApiGen\Reflection\ReflectionFunction', $function);
+            $this->checkLoadedProperties($function);
+        }
+        $constants = $this->backend->getConstants();
+        $this->assertCount(2, $constants);
+        foreach ($constants as $constant)
+        {
+            $this->assertInstanceOf('ApiGen\Reflection\ReflectionConstant', $constant);
+            $this->checkLoadedProperties($constant);
+        }
+    }
+
+    public function testPhp56VariadicFunctions(): void
+    {
+        $this->broker->processDirectory(__DIR__ . '/BackendSourcePhp56VariadicFunctions');
+        $functions = $this->backend->getFunctions();
+        $this->assertCount(2, $functions);
+        $function = array_pop($functions);
+        $this->assertInstanceOf('ApiGen\Reflection\ReflectionFunction', $function);
+        $this->checkLoadedProperties($function);
+    }
+
     /**
      * @param object $object
      */

--- a/tests/Parser/Broker/BackendTest.php
+++ b/tests/Parser/Broker/BackendTest.php
@@ -70,6 +70,11 @@ final class BackendTest extends TestCase
 
     public function testPhp56DefaultArguments(): void
     {
+        // Test is incomplete due to PHP 5.6 Support
+        $this->markTestIncomplete(
+          'This test has not been implemented yet due to full PHP 5.6 support missing [PR #500].'
+        );
+
         $this->broker->processDirectory(__DIR__ . '/BackendSourcePhp56DefaultArguments');
         $functions = $this->backend->getFunctions();
         $this->assertCount(2, $functions);
@@ -91,10 +96,17 @@ final class BackendTest extends TestCase
             $this->assertInstanceOf('ApiGen\Reflection\ReflectionConstant', $constant);
             $this->checkLoadedProperties($constant);
         }
+
     }
 
     public function testPhp56Namespaces(): void
     {
+
+        // Test is incomplete due to PHP 5.6 Support
+        $this->markTestIncomplete(
+          'This test has not been implemented yet due to full PHP 5.6 support missing [PR #500].'
+        );
+
         $this->broker->processDirectory(__DIR__ . '/BackendSourcePhp56Namespaces');
         $functions = $this->backend->getFunctions();
         $this->assertCount(3, $functions);
@@ -109,16 +121,23 @@ final class BackendTest extends TestCase
             $this->assertInstanceOf('ApiGen\Reflection\ReflectionConstant', $constant);
             $this->checkLoadedProperties($constant);
         }
+
     }
 
     public function testPhp56VariadicFunctions(): void
     {
+        // Test is incomplete due to PHP 5.6 Support
+        $this->markTestIncomplete(
+          'This test has not been implemented yet due to full PHP 5.6 support missing [PR #500].'
+        );
+
         $this->broker->processDirectory(__DIR__ . '/BackendSourcePhp56VariadicFunctions');
         $functions = $this->backend->getFunctions();
         $this->assertCount(2, $functions);
         $function = array_pop($functions);
         $this->assertInstanceOf('ApiGen\Reflection\ReflectionFunction', $function);
         $this->checkLoadedProperties($function);
+
     }
 
     /**


### PR DESCRIPTION
This PR merges PHP5.6 tests from PR #500 to maser. I've marked the tests as incomplete so they won't interfere with CI process.

Example output with incomplete tests (it still passes):

```bash
PHPUnit 6.0.13 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.3 with Xdebug 2.5.1
Configuration: /home/edv/projects/ek9/code/php/apigen/phpunit.xml.dist

.............................................................II  63 / 361 ( 17%)
I.............................................................. 126 / 361 ( 34%)
............................................................... 189 / 361 ( 52%)
............................................................... 252 / 361 ( 69%)
............................................................... 315 / 361 ( 87%)
..............................................                  361 / 361 (100%)

Time: 2.97 seconds, Memory: 36.00MB

There were 3 incomplete tests:

1) ApiGen\Parser\Tests\Broker\BackendTest::testPhp56DefaultArguments
This test has not been implemented yet due to full PHP 5.6 support missing [PR #500].

./tests/Parser/Broker/BackendTest.php:75

2) ApiGen\Parser\Tests\Broker\BackendTest::testPhp56Namespaces
This test has not been implemented yet due to full PHP 5.6 support missing [PR #500].

./tests/Parser/Broker/BackendTest.php:107

3) ApiGen\Parser\Tests\Broker\BackendTest::testPhp56VariadicFunctions
This test has not been implemented yet due to full PHP 5.6 support missing [PR #500].

./tests/Parser/Broker/BackendTest.php:131

OK, but incomplete, skipped, or risky tests!
Tests: 361, Assertions: 535, Incomplete: 3.

```