### PR TITLE
Expand Composer AutoLoader Searchable Paths

### DIFF
--- a/bin/apigen
+++ b/bin/apigen
@@ -7,8 +7,18 @@ use Symfony\Component\Console\Application;
 // Performance boost
 gc_disable();
 
-// Require Composer autoload
-require_once getcwd() . '/vendor/autoload.php';
+$possibleAutoloadPaths = [
+    getcwd() . '/vendor/autoload.php',
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php'
+];
+
+foreach( $possibleAutoloadPaths as $possibleAutoloadPath ) {
+
+     if( stream_resolve_include_path( $possibleAutoloadPath ) !== FALSE ) {
+        require_once( $possibleAutoloadPath ); break;
+     }
+}
 
 $container = (new ContainerFactory())->create();
 /** @var Application $application */

--- a/bin/apigen
+++ b/bin/apigen
@@ -13,14 +13,15 @@ $possibleAutoloadPaths = [
     __DIR__ . '/../../../autoload.php'
 ];
 
-foreach( $possibleAutoloadPaths as $possibleAutoloadPath ) {
-
-     if( stream_resolve_include_path( $possibleAutoloadPath ) !== FALSE ) {
-        require_once( $possibleAutoloadPath ); break;
-     }
+foreach ($possibleAutoloadPaths as $possibleAutoloadPath) {
+    if (file_exists($possibleAutoloadPath)) {
+        require_once $possibleAutoloadPath;
+        break;
+    }
 }
 
 $container = (new ContainerFactory())->create();
+
 /** @var Application $application */
 $application = $container->get(Application::class);
 $application->run();


### PR DESCRIPTION
Expanding the the searchable path to locate Composer's AutoLoader in order to, possibly, Fix issue #888