### PR TITLE
updated test [failing]

### DIFF
--- a/packages/Element/src/Latte/Filter/PhpHighlightFilter.php
+++ b/packages/Element/src/Latte/Filter/PhpHighlightFilter.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Element\Latte\Filter;
+
+use ApiGen\Contract\Templating\FilterProviderInterface;
+use ApiGen\SourceCodeHighlighter\SourceCodeHighlighter;
+
+final class PhpHighlightFilter implements FilterProviderInterface
+{
+    /**
+     * @var SourceCodeHighlighter
+     */
+    private $highlighter;
+
+    public function __construct(SourceCodeHighlighter $highlighter)
+    {
+        $this->highlighter = $highlighter;
+    }
+
+    /**
+     * @return callable[]
+     */
+    public function getFilters(): array
+    {
+        return [
+            // use in .latte: {$method|phpHighlight}
+            'phpHighlight' => function ($code) {
+                return $this->highlighter->highlight($code);
+            }
+        ];
+    }
+}

--- a/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
+++ b/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
@@ -172,7 +172,7 @@ final class ClassPropertyReflection implements ClassPropertyReflectionInterface,
 
     public function getDefaultValueDefinition(): ?string
     {
-        return $this->betterPropertyReflection->getDefaultValue();
+        return $this->betterPropertyReflection->getDefaultValueAsString();
     }
 
     public function isDeprecated(): bool

--- a/packages/ThemeDefault/src/partial/property.latte
+++ b/packages/ThemeDefault/src/partial/property.latte
@@ -27,7 +27,7 @@
     <td class="value">
         <div>
             <a href="#${$property->getName()}" class="anchor pull-right">#</a>
-            <code>{$property->getDefaultValueDefinition()}</code>
+            <code class="php-code">{$property->getDefaultValueDefinition()|phpHighlight|noescape}</code>
         </div>
     </td>
 </tr>

--- a/packages/ThemeDefault/src/resources/style.css
+++ b/packages/ThemeDefault/src/resources/style.css
@@ -272,6 +272,9 @@ table .name > div > code span
 #source pre.code {
     padding-left: 0;
 }
+code.php-code {
+    color: inherit;
+}
 
 .php-keyword1 {
     color: #e71818;

--- a/tests/Generator/Source/SomeClass.php
+++ b/tests/Generator/Source/SomeClass.php
@@ -4,5 +4,9 @@ namespace ApiGen\Tests\Generator\Source;
 
 class SomeClass
 {
+	public $stringProperty = 'string';
 
+	public $arrayProperty = ['cat', 'dog'];
+
+	public $integerProperty = 11;
 }


### PR DESCRIPTION
`ClassMethodReflection::getDefaultValueDefinition()` can return mixed types but typehint is only for string. The same goes for `TraitMethodReflection::getDefaultValueDefinition()`.

Some variable dumper must be added or real definition loaded in some way.

Any tips how to solve it?