### PR TITLE
fixed souce code line highlighting

### DIFF
--- a/packages/ThemeDefault/src/@layout.latte
+++ b/packages/ThemeDefault/src/@layout.latte
@@ -39,11 +39,11 @@
         </div>
 
         {* jquery autocomplete *}
-        <script src="https://code.jquery.com/jquery-3.2.1.min.js" defer></script>
-        <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" defer></script>
+        <script src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
 
-        <script src="/resources/main.js"></script>
-        <script src="/elementlist.js"></script>
+        <script src="elementlist.js"></script>
+        <script src="resources/main.js"></script>
     </body>
 </html>
 

--- a/packages/ThemeDefault/src/resources/main.js
+++ b/packages/ThemeDefault/src/resources/main.js
@@ -1,9 +1,9 @@
 // $( function() {
-$(window).load(function() {
+$(document).ready(function() {
     var $document = $(document);
 
     // Content
-
+/*
     var availableTags = [
         "ActionScript",
         "Able"
@@ -69,6 +69,8 @@ $(window).load(function() {
                 }
                 return !autocompleteFound && '' !== $('#search input[name=cx]').val();
             });
+*/
+
 
     // Select selected lines
     var matches = window.location.hash.substr(1).match(/^\d+(?:-\d+)?(?:,\d+(?:-\d+)?)*$/);

--- a/packages/ThemeDefault/src/resources/main.js
+++ b/packages/ThemeDefault/src/resources/main.js
@@ -146,7 +146,7 @@ $(document).ready(function() {
             }
         }
 
-        hash = hash.join(',');
+        hash = '#' + hash.join(',');
         history.pushState(null, null, hash);
     });
 });

--- a/packages/ThemeDefault/src/resources/main.js
+++ b/packages/ThemeDefault/src/resources/main.js
@@ -81,7 +81,7 @@ $(document).ready(function() {
             lines[0] = parseInt(lines[0]);
             lines[1] = parseInt(lines[1] || lines[0]);
             for (var j = lines[0]; j <= lines[1]; j++) {
-                $('#' + j).addClass('selected');
+                $('#' + j + ', #line-' + j).addClass('selected');
             }
         }
 
@@ -93,37 +93,30 @@ $(document).ready(function() {
 
     // Save selected lines
     var lastLine;
-    $('.l a').click(function(event) {
+    $('.numbers .l a').click(function(event) {
         event.preventDefault();
 
         var selectedLine = $(this).parent().index() + 1;
-        var $selectedLine = $('pre.code .l').eq(selectedLine - 1);
 
         if (event.shiftKey) {
             if (lastLine) {
                 for (var i = Math.min(selectedLine, lastLine); i <= Math.max(selectedLine, lastLine); i++) {
-                    $('#' + i).addClass('selected');
+                    $('#' + i + ', #line-' + i).addClass('selected');
                 }
             } else {
-                $selectedLine.addClass('selected');
+                 $('#' + selectedLine + ', #line-' + selectedLine).addClass('selected');
             }
         } else if (event.ctrlKey) {
-            $selectedLine.toggleClass('selected');
+              $('#' + selectedLine + ', #line-' + selectedLine).toggleClass('selected');
         } else {
-            var $selected = $('.l.selected')
-                .not($selectedLine)
-                .removeClass('selected');
-            if ($selected.length > 0) {
-                $selectedLine.addClass('selected');
-            } else {
-                $selectedLine.toggleClass('selected');
-            }
+           var selected = $('.l.selected').not('#' + selectedLine + ', #line-' + selectedLine).removeClass('selected');
+           $('#' + selectedLine + ', #line-' + selectedLine).addClass('selected');
         }
 
-        lastLine = $selectedLine.hasClass('selected') ? selectedLine : null;
+        lastLine = $('#' + selectedLine).hasClass('selected') ? selectedLine : null;
 
         // Update hash
-        var lines = $('.l.selected')
+        var lines = $('.numbers .l.selected')
             .map(function() {
                 return parseInt($(this).attr('id'));
             })
@@ -154,8 +147,6 @@ $(document).ready(function() {
         }
 
         hash = hash.join(',');
-        $backup = $('#' + hash).removeAttr('id');
-        window.location.hash = hash;
-        $backup.attr('id', hash);
+        history.pushState(null, null, hash);
     });
 });

--- a/packages/ThemeDefault/src/resources/style.css
+++ b/packages/ThemeDefault/src/resources/style.css
@@ -258,6 +258,21 @@ table .name > div > code span
 }
 
 /* Source code */
+#source pre {
+    background: none;
+    border: 0;
+}
+#source pre.numbers {
+    padding-right: 0;
+}
+#source pre.numbers a {
+    background: transparent;
+    color: #929292 !important;
+}
+#source pre.code {
+    padding-left: 0;
+}
+
 .php-keyword1 {
     color: #e71818;
     font-weight: bold;

--- a/packages/ThemeDefault/src/source.latte
+++ b/packages/ThemeDefault/src/source.latte
@@ -6,7 +6,7 @@
     <div id="source">
         {var $lineCount =substr_count($source, "\n")}
         {var $lineRegex = '~<span class="line">(\\s*(\\d+):\\s*)</span>([^\\n]*(?:\\n|$))~'}
-        <pre class="numbers"><code>{$source|replaceRE:$lineRegex,'<span class="l"><a href="#$2">$1</a></span>'|noescape}</code></pre>
-        <pre class="code"><code>{$source|replaceRE:$lineRegex,'<span id="$2" class="l">$3</span>'|noescape}<br></code></pre>
+        <pre class="numbers"><code>{$source|replaceRE:$lineRegex,'<span id="$2" class="l"><a href="#$2">$1</a></span>'|noescape}</code></pre>
+        <pre class="code"><code>{$source|replaceRE:$lineRegex,'<span class="l" id="line-$2">$3</span>'|noescape}<br></code></pre>
     </div>
 {/block}


### PR DESCRIPTION
Related to #884 

My goal was to imitate behaviour of latest Nette's API and one of Doctrine ORM. There was a little problem with line numbers styling for in former versions of ApiGen number and source code has been wrapped in one HTML element and in current version this is done differently. But I solve it.

Autocomplete has been removed temporarily, for it broke the highlighting.