### PR TITLE
fixed function parameter reflection

### DIFF
--- a/packages/Reflection/src/Contract/Reflection/AbstractParameterReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/AbstractParameterReflectionInterface.php
@@ -14,6 +14,8 @@ interface AbstractParameterReflectionInterface extends AbstractReflectionInterfa
      */
     public function getTypeHintClassOrInterfaceReflection();
 
+    public function isDefaultValueAvailable(): bool;
+
     public function getDefaultValueDefinition(): ?string;
 
     public function isArray(): bool;

--- a/packages/Reflection/src/Reflection/AbstractParameterReflection.php
+++ b/packages/Reflection/src/Reflection/AbstractParameterReflection.php
@@ -2,6 +2,7 @@
 
 namespace ApiGen\Reflection\Reflection;
 
+use ApiGen\Annotation\AnnotationList;
 use ApiGen\Reflection\Contract\Reflection\AbstractParameterReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassMethodReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
@@ -67,6 +68,11 @@ abstract class AbstractParameterReflection implements AbstractParameterReflectio
         return $classOrInterfaceReflection;
     }
 
+    public function isDefaultValueAvailable(): bool
+    {
+        return $this->betterParameterReflection->isDefaultValueAvailable();
+    }
+
     public function getDefaultValueDefinition(): ?string
     {
         if ($this->betterParameterReflection->isDefaultValueAvailable()) {
@@ -118,7 +124,7 @@ abstract class AbstractParameterReflection implements AbstractParameterReflectio
     private function getAnnotation(): ?Param
     {
         $declaringReflection = $this->getDeclaringReflection();
-        $annotations = $declaringReflection->getAnnotations();
+        $annotations = $declaringReflection->getAnnotation(AnnotationList::PARAM);
 
         if (empty($annotations[$this->betterParameterReflection->getPosition()])) {
             return null;

--- a/packages/Reflection/src/Reflection/Trait_/TraitMethodReflection.php
+++ b/packages/Reflection/src/Reflection/Trait_/TraitMethodReflection.php
@@ -13,6 +13,11 @@ use Roave\BetterReflection\Reflection\ReflectionMethod;
 final class TraitMethodReflection implements TraitMethodReflectionInterface, TransformerCollectorAwareInterface
 {
     /**
+     * @var string
+     */
+    private const EMPTY_LINE = PHP_EOL . PHP_EOL;
+
+    /**
      * @var ReflectionMethod
      */
     private $betterMethodReflection;
@@ -93,12 +98,26 @@ final class TraitMethodReflection implements TraitMethodReflectionInterface, Tra
 
     public function isDeprecated(): bool
     {
-        // TODO: Implement isDeprecated() method.
+        if ($this->betterMethodReflection->isDeprecated()) {
+            return true;
+        }
+
+        return $this->getDeclaringTrait()
+            ->isDeprecated();
     }
 
     public function getDescription(): string
     {
-        // TODO: Implement getDescription() method.
+        $description = $this->docBlock->getSummary()
+            . self::EMPTY_LINE
+            . $this->docBlock->getDescription();
+
+        return trim($description);
+    }
+
+    public function getOverriddenMethod(): ?TraitMethodReflectionInterface
+    {
+        return null;
     }
 
     /**

--- a/packages/ThemeDefault/src/class.latte
+++ b/packages/ThemeDefault/src/class.latte
@@ -79,7 +79,7 @@
         <table class="summary table table-bordered table-responsive table-striped" id="methods">
             <tr><th colspan="3">Methods Summary</th></tr>
             {foreach $class->getOwnMethods() as $method}
-                {include "partial/method.latte", method => $method}
+                {include "partial/method.latte", method => $method, "isClass" => true}
             {/foreach}
         </table>
     {/if}

--- a/packages/ThemeDefault/src/function.latte
+++ b/packages/ThemeDefault/src/function.latte
@@ -51,7 +51,7 @@
                     <span class="property-name">{if $parameter->isPassedByReference()}&amp; {/if}${$parameter->getName()}</span>
                     {if $parameter->isDefaultValueAvailable()} = {$parameter->getDefaultValueDefinition()|highlightValue:$function|noescape}{elseif $parameter->isVariadic()},…{/if}
                 {/block}</code></td>
-                <td>{$parameter|description}</td>
+                <td>{if $parameter instanceof \ApiGen\Reflection\Contract\Reflection\Partial\AnnotationsInterface}{$parameter|description}{/if}</td>
             </tr>
         </table>
     {/if}

--- a/packages/ThemeDefault/src/partial/method.latte
+++ b/packages/ThemeDefault/src/partial/method.latte
@@ -1,4 +1,5 @@
 {if !isset($isInterface)}{$isInterface = false}{/if}
+{if !isset($isClass)}{$isClass = false}{/if}
 
 <tr id="_{$method->getName()}" n:class="$method->isDeprecated() ? deprecated">
     {var $annotations = $method->getAnnotations()}
@@ -85,7 +86,7 @@
                     </div>
                 {/foreach}
 
-                {if $isInterface === false}
+                {if $isClass === true}
                     {if $method->getOverriddenMethod()}
                         <h2>Overrides</h2>
                         <div>

--- a/tests/Generator/Source/SomeClass.php
+++ b/tests/Generator/Source/SomeClass.php
@@ -4,5 +4,11 @@ namespace ApiGen\Tests\Generator\Source;
 
 class SomeClass
 {
-
+    /**
+     * Do not add param annotations here!
+     * @return void
+     */
+    public function functionWithoutParamAnnotations($paramWithoutTypeHint)
+    {
+    }
 }

--- a/tests/Generator/Source/SomeFunction.php
+++ b/tests/Generator/Source/SomeFunction.php
@@ -6,6 +6,10 @@ function someFunction(): void
 {
 }
 
-function someOtherFunction(): void
+/**
+ * Do not add param annotations here!
+ * @return void
+ */
+function someOtherFunction($paramWithoutTypeHint)
 {
 }

--- a/tests/Generator/Source/SomeTrait.php
+++ b/tests/Generator/Source/SomeTrait.php
@@ -4,5 +4,11 @@ namespace ApiGen\Tests\Generator\Source;
 
 trait SomeTrait
 {
-
+    /**
+     * Do not add param annotations here!
+     * @return void
+     */
+    public function functionWithoutParamAnnotations($paramWithoutTypeHint)
+    {
+    }
 }


### PR DESCRIPTION
```
ApiGen\Exception\Templating\FailedRenderFileException: Rendering of "/home/*/apigen/packages/ThemeDefault/src/function.latte" template to "/tmp/_apigen_cache/function-ApiGen.Tests.Generator.Source.someOtherFunction.html" file failed due to: Return value of ApiGen\Reflection\Reflection\AbstractParameterReflection::getAnnotation() must be an instance of phpDocumentor\Reflection\DocBlock\Tags\Param or null, instance of phpDocumentor\Reflection\DocBlock\Tags\Return_ returned
```


```
ApiGen\Exception\Templating\FailedRenderFileException: Rendering of "/home/*/apigen/packages/ThemeDefault/src/function.latte" template to "/tmp/_apigen_cache/function-ApiGen.Tests.Generator.Source.someOtherFunction.html" file failed due to: Call to undefined method ApiGen\Reflection\Reflection\Function_\FunctionParameterReflection::isDefaultValueAvailable()
```


```
ApiGen\Exception\Templating\FailedRenderFileException: Rendering of "/home/*/apigen/packages/ThemeDefault/src/function.latte" template to "/tmp/_apigen_cache/function-ApiGen.Tests.Generator.Source.someOtherFunction.html" file failed due to: Argument 1 passed to ApiGen\Annotation\Latte\Filter\AnnotationFilterProvider::ApiGen\Annotation\Latte\Filter\{closure}() must implement interface ApiGen\Reflection\Contract\Reflection\Partial\AnnotationsInterface, instance of ApiGen\Reflection\Reflection\Function_\FunctionParameterReflection given, called in /tmp/_latte_cache/ThemeDefault-src-function.latte--2096778438.php on line 154
```