### PR TITLE
Fixed messy output in console.

### DIFF
--- a/src/Console/Progress/StepCounter.php
+++ b/src/Console/Progress/StepCounter.php
@@ -32,7 +32,8 @@ final class StepCounter
             + count($this->reflectionStorage->getClassReflections())
             + count($this->reflectionStorage->getTraitReflections())
             + count($this->reflectionStorage->getInterfaceReflections())
-            + count($this->reflectionStorage->getFunctionReflections());
+            + count($this->reflectionStorage->getFunctionReflections())
+            + $this->getOverviewPagesCount();
     }
 
     private function getSourceCodeStepCount(): int
@@ -41,5 +42,23 @@ final class StepCounter
             + count($this->reflectionStorage->getInterfaceReflections())
             + count($this->reflectionStorage->getTraitReflections())
             + count($this->reflectionStorage->getFunctionReflections());
+    }
+
+    private function getOverviewPagesCount(): int
+    {
+        $count = 2; // index.html + elementlist.js
+        if (count($this->reflectionStorage->getClassReflections())) {
+            $count++; // classes.html
+        }
+        if (count($this->reflectionStorage->getInterfaceReflections())) {
+            $count++; // interfaces.html
+        }
+        if (count($this->reflectionStorage->getTraitReflections())) {
+            $count++; // traits.html
+        }
+        if (count($this->reflectionStorage->getFunctionReflections())) {
+            $count++; // functions.html
+        }
+        return $count;
     }
 }


### PR DESCRIPTION
In short, `StepCounter` did not count files like `index.html`, `classes.html` etc. Beacuse of this, progressbar's maximum was lesser than actual count of generated files.

It solves #902 