### PR TITLE
[testing] Avoid using autoload file from current working dir

### DIFF
--- a/bin/apigen
+++ b/bin/apigen
@@ -8,7 +8,6 @@ use Symfony\Component\Console\Application;
 gc_disable();
 
 $possibleAutoloadPaths = [
-    getcwd() . '/vendor/autoload.php',
     __DIR__ . '/../vendor/autoload.php',
     __DIR__ . '/../../../autoload.php'
 ];


### PR DESCRIPTION
Test if works what I mention in https://github.com/ApiGen/ApiGen/issues/900#issuecomment-312199321.

Avoid load the project vendors instead of ApiGen vendor.

> Sorry, I have not PHP 7.1 in my computer to test this locally.