### PR TITLE
Theme: split classes and exceptions in namespace summary

### DIFF
--- a/packages/Element/src/ReflectionCollector/NamespaceReflectionCollector.php
+++ b/packages/Element/src/ReflectionCollector/NamespaceReflectionCollector.php
@@ -10,6 +10,7 @@ use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterfac
 use ApiGen\Reflection\Contract\Reflection\Partial\InNamespaceInterface;
 use ApiGen\Reflection\Contract\Reflection\Trait_\TraitReflectionInterface;
 use ApiGen\Reflection\Helper\ReflectionAnalyzer;
+use Throwable;
 
 final class NamespaceReflectionCollector implements BasicReflectionCollectorInterface
 {
@@ -40,6 +41,10 @@ final class NamespaceReflectionCollector implements BasicReflectionCollectorInte
         $reflectionInterface = ReflectionAnalyzer::getReflectionInterfaceFromReflection($reflection);
         $namespace = $reflection->getNamespaceName() ?: self::NO_NAMESPACE;
 
+        if ($reflectionInterface === ClassReflectionInterface::class) {
+            $reflectionInterface = ($reflection->implementsInterface(Throwable::class)) ? 'exception' : 'class';
+        }
+
         $this->collectedReflections[$namespace][$reflectionInterface][$reflection->getName()] = $reflection;
     }
 
@@ -48,7 +53,15 @@ final class NamespaceReflectionCollector implements BasicReflectionCollectorInte
      */
     public function getClassReflections(string $namespace): array
     {
-        return $this->collectedReflections[$namespace][ClassReflectionInterface::class] ?? [];
+        return $this->collectedReflections[$namespace]['class'] ?? [];
+    }
+
+    /**
+     * @return ClassReflectionInterface[]
+     */
+    public function getExceptionReflections(string $namespace): array
+    {
+        return $this->collectedReflections[$namespace]['exception'] ?? [];
     }
 
     /**

--- a/packages/Reflection/src/ReflectionStorage.php
+++ b/packages/Reflection/src/ReflectionStorage.php
@@ -6,6 +6,7 @@ use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Function_\FunctionReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Trait_\TraitReflectionInterface;
+use Throwable;
 
 final class ReflectionStorage
 {
@@ -13,6 +14,11 @@ final class ReflectionStorage
      * @var ClassReflectionInterface[]
      */
     private $classReflections = [];
+
+    /**
+     * @var ClassReflectionInterface[]
+     */
+    private $exceptionReflections = [];
 
     /**
      * @var InterfaceReflectionInterface[]
@@ -38,6 +44,14 @@ final class ReflectionStorage
     }
 
     /**
+     * @return ClassReflectionInterface[]
+     */
+    public function getExceptionReflections(): array
+    {
+        return $this->exceptionReflections;
+    }
+
+    /**
      * @param ClassReflectionInterface[] $classReflections
      */
     public function addClassReflections(array $classReflections): void
@@ -46,7 +60,11 @@ final class ReflectionStorage
         });
         sort($classReflections);
         foreach ($classReflections as $classReflection) {
-            $this->classReflections[$classReflection->getName()] = $classReflection;
+            if ($classReflection->implementsInterface(Throwable::class)) {
+                $this->exceptionReflections[$classReflection->getName()] = $classReflection;
+            } else {
+                $this->classReflections[$classReflection->getName()] = $classReflection;
+            }
         }
     }
 

--- a/packages/StringRouting/src/Route/ReflectionRoute.php
+++ b/packages/StringRouting/src/Route/ReflectionRoute.php
@@ -17,6 +17,7 @@ use ApiGen\Reflection\Contract\Reflection\Trait_\TraitPropertyReflectionInterfac
 use ApiGen\Reflection\Contract\Reflection\Trait_\TraitReflectionInterface;
 use ApiGen\StringRouting\Contract\Route\RouteInterface;
 use ApiGen\Utils\NamingHelper;
+use Throwable;
 
 final class ReflectionRoute implements RouteInterface
 {
@@ -35,6 +36,10 @@ final class ReflectionRoute implements RouteInterface
      */
     public function constructUrl($reflection): string
     {
+        if ($reflection instanceof ClassReflectionInterface && $reflection->implementsInterface(Throwable::class)) {
+            return 'exception-' . NamingHelper::nameToFilePath($reflection->getName()) . '.html';
+        }
+
         if ($reflection instanceof ClassReflectionInterface) {
             return 'class-' . NamingHelper::nameToFilePath($reflection->getName()) . '.html';
         }

--- a/packages/StringRouting/src/Route/SourceCodeRoute.php
+++ b/packages/StringRouting/src/Route/SourceCodeRoute.php
@@ -14,6 +14,7 @@ use ApiGen\Reflection\Contract\Reflection\Trait_\TraitReflectionInterface;
 use ApiGen\StringRouting\Contract\Route\RouteInterface;
 use ApiGen\Utils\NamingHelper;
 use ApiGen\Utils\RelativePathResolver;
+use Throwable;
 
 final class SourceCodeRoute implements RouteInterface
 {
@@ -43,6 +44,10 @@ final class SourceCodeRoute implements RouteInterface
     public function constructUrl($reflection): string
     {
         # todo: allow Github links, based on configuration
+        if ($reflection instanceof ClassReflectionInterface && $reflection->implementsInterface(Throwable::class)) {
+            return 'source-exception-' . NamingHelper::nameToFilePath($reflection->getName()) . '.html';
+        }
+
         if ($reflection instanceof ClassReflectionInterface) {
             return 'source-class-' . NamingHelper::nameToFilePath($reflection->getName()) . '.html';
         }

--- a/packages/StringRouting/tests/Route/ReflectionRouteTest.php
+++ b/packages/StringRouting/tests/Route/ReflectionRouteTest.php
@@ -16,6 +16,7 @@ use ApiGen\Reflection\Contract\Reflection\Trait_\TraitReflectionInterface;
 use ApiGen\StringRouting\Route\ReflectionRoute;
 use ApiGen\StringRouting\StringRouter;
 use ApiGen\Tests\AbstractContainerAwareTestCase;
+use Throwable;
 
 final class ReflectionRouteTest extends AbstractContainerAwareTestCase
 {
@@ -66,6 +67,21 @@ final class ReflectionRouteTest extends AbstractContainerAwareTestCase
             [InterfaceReflectionInterface::class, 'interface-SomeName.html'],
             [TraitReflectionInterface::class, 'trait-SomeName.html'],
         ];
+    }
+
+    public function testExceptionReflection(): void
+    {
+        $reflectionExceptionMock = $this->createMock(ClassReflectionInterface::class);
+        $reflectionExceptionMock->method('implementsInterface')
+            ->with(Throwable::class)
+            ->willReturn(true);
+        $reflectionExceptionMock->method('getName')
+            ->willReturn('SomeException');
+
+        $this->assertSame(
+            'exception-SomeException.html',
+            $this->stringRouter->buildRoute(ReflectionRoute::NAME, $reflectionExceptionMock)
+        );
     }
 
     public function testFunctionUrl(): void

--- a/packages/ThemeDefault/src/@elementlist.latte
+++ b/packages/ThemeDefault/src/@elementlist.latte
@@ -36,3 +36,10 @@
         {include elements, elements => $allFunctions}
     </table>
 {/if}
+
+{if $exceptions}
+    <table class="summary table table-responsive table-bordered table-striped" id="exceptions">
+        <tr><th colspan="2">Exceptions Summary</th></tr>
+        {include elements, elements => $exceptions}
+    </table>
+{/if}

--- a/packages/ThemeDefault/src/exceptions.latte
+++ b/packages/ThemeDefault/src/exceptions.latte
@@ -1,0 +1,17 @@
+{layout '@layout.latte'}
+
+{block title}{$pageTitle}{/block}
+
+{block content}
+    <h1>{$pageTitle}</h1>
+
+    <table class="summary table table-bordered table-responsive table-striped">
+        {foreach $exceptions as $exception}
+            <tr>
+                <td class="name">
+                    <a href="{$exception|linkReflection}">{$exception->getName()}</a>
+                </td>
+            </tr>
+        {/foreach}
+    </table>
+{/block}

--- a/packages/ThemeDefault/src/index.latte
+++ b/packages/ThemeDefault/src/index.latte
@@ -19,6 +19,7 @@
     {if count($allNamespaces) <= 1}
         {include '@elementlist.latte',
             "classes" => $allClasses,
+            "exceptions" => $allExceptions,
             "interfaces" => $allInterfaces,
             "traits" => $allTraits,
             "functions" => $allFunctions

--- a/packages/ThemeDefault/src/namespace.latte
+++ b/packages/ThemeDefault/src/namespace.latte
@@ -27,6 +27,7 @@
 
     {include '@elementlist.latte',
         "classes" => $classes,
+        "exceptions" => $exceptions,
         "intefaces" => $interfaces,
         "traits" => $traits,
         "functions" => $functions

--- a/packages/ThemeDefault/src/partial/menu.latte
+++ b/packages/ThemeDefault/src/partial/menu.latte
@@ -34,6 +34,12 @@
                             </li>
                         {/if}
 
+                        {if count($allExceptions)}
+                            <li>
+                                <a n:class="$activePage === exceptions ? active" href="exceptions.html">Exceptions</a>
+                            </li>
+                        {/if}
+
                         {foreach $annotationGroups as $annotationGroup}
                             <li class="separator"></li>
                             <li>

--- a/src/Console/Progress/StepCounter.php
+++ b/src/Console/Progress/StepCounter.php
@@ -30,6 +30,7 @@ final class StepCounter
         return $this->getSourceCodeStepCount()
             + count($this->namespaceReflectionCollector->getNamespaces())
             + count($this->reflectionStorage->getClassReflections())
+            + count($this->reflectionStorage->getExceptionReflections())
             + count($this->reflectionStorage->getTraitReflections())
             + count($this->reflectionStorage->getInterfaceReflections())
             + count($this->reflectionStorage->getFunctionReflections())
@@ -39,6 +40,7 @@ final class StepCounter
     private function getSourceCodeStepCount(): int
     {
         return count($this->reflectionStorage->getClassReflections())
+            + count($this->reflectionStorage->getExceptionReflections())
             + count($this->reflectionStorage->getInterfaceReflections())
             + count($this->reflectionStorage->getTraitReflections())
             + count($this->reflectionStorage->getFunctionReflections());
@@ -49,6 +51,10 @@ final class StepCounter
         $count = 2; // index.html + elementlist.js
         if (count($this->reflectionStorage->getClassReflections())) {
             $count++; // classes.html
+        }
+
+        if (count($this->reflectionStorage->getExceptionReflections())) {
+            $count++; // exceptions.html
         }
 
         if (count($this->reflectionStorage->getInterfaceReflections())) {

--- a/src/EventSubscriber/ElementsTemplateVariablesEventSubscriber.php
+++ b/src/EventSubscriber/ElementsTemplateVariablesEventSubscriber.php
@@ -53,6 +53,7 @@ final class ElementsTemplateVariablesEventSubscriber implements EventSubscriberI
         $parameterBag->addParameters([
             'allNamespaces' => $this->namespaceReflectionCollector->getNamespaces(),
             'allClasses' => $this->reflectionStorage->getClassReflections(),
+            'allExceptions' => $this->reflectionStorage->getExceptionReflections(),
             'allInterfaces' => $this->reflectionStorage->getInterfaceReflections(),
             'allTraits' => $this->reflectionStorage->getTraitReflections(),
             'allFunctions' => $this->reflectionStorage->getFunctionReflections()

--- a/src/Generator/EmptyNamespaceGenerator.php
+++ b/src/Generator/EmptyNamespaceGenerator.php
@@ -66,6 +66,7 @@ final class EmptyNamespaceGenerator implements GeneratorInterface
                 'activeNamespace' => $namespace,
                 'childNamespaces' => $this->resolveChildNamespaces($namespace),
                 'classes' => [],
+                'exceptions' => [],
                 'interfaces' => [],
                 'traits' => [],
                 'functions' => [],

--- a/src/Generator/ExceptionGenerator.php
+++ b/src/Generator/ExceptionGenerator.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Generator;
+
+use ApiGen\Configuration\Configuration;
+use ApiGen\Contract\Generator\GeneratorInterface;
+use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
+use ApiGen\Reflection\ReflectionStorage;
+use ApiGen\SourceCodeHighlighter\SourceCodeHighlighter;
+use ApiGen\Templating\TemplateRenderer;
+
+final class ExceptionGenerator implements GeneratorInterface
+{
+    /**
+     * @var ReflectionStorage
+     */
+    private $reflectionStorage;
+
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * @var SourceCodeHighlighter
+     */
+    private $sourceCodeHighlighter;
+
+    /**
+     * @var TemplateRenderer
+     */
+    private $templateRenderer;
+
+    public function __construct(
+        ReflectionStorage $reflectionStorage,
+        Configuration $configuration,
+        SourceCodeHighlighter $sourceCodeHighlighter,
+        TemplateRenderer $templateRenderer
+    ) {
+        $this->reflectionStorage = $reflectionStorage;
+        $this->configuration = $configuration;
+        $this->sourceCodeHighlighter = $sourceCodeHighlighter;
+        $this->templateRenderer = $templateRenderer;
+    }
+
+    public function generate(): void
+    {
+        foreach ($this->reflectionStorage->getExceptionReflections() as $exceptionReflection) {
+            $this->generateForException($exceptionReflection);
+            $this->generateSourceCodeForException($exceptionReflection);
+        }
+    }
+
+    private function generateForException(ClassReflectionInterface $exceptionReflection): void
+    {
+        $this->templateRenderer->renderToFile(
+            $this->configuration->getTemplateByName('class'),
+            $this->configuration->getDestinationWithPrefixName('exception-', $exceptionReflection->getName()),
+            [
+                'activePage' => 'exception',
+                'class' => $exceptionReflection,
+            ]
+        );
+    }
+
+    private function generateSourceCodeForException(ClassReflectionInterface $exceptionReflection): void
+    {
+        $content = file_get_contents($exceptionReflection->getFileName());
+        $highlightedContent = $this->sourceCodeHighlighter->highlightAndAddLineNumbers($content);
+
+        $this->templateRenderer->renderToFile(
+            $this->configuration->getTemplateByName('source'),
+            $this->configuration->getDestinationWithPrefixName('source-exception-', $exceptionReflection->getName()),
+            [
+                'activePage' => 'class',
+                'activeClass' => $exceptionReflection,
+                'fileName' => $exceptionReflection->getFileName(),
+                'source' => $highlightedContent
+            ]
+        );
+    }
+}

--- a/src/Generator/ExceptionsGenerator.php
+++ b/src/Generator/ExceptionsGenerator.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Generator;
+
+use ApiGen\Configuration\Configuration;
+use ApiGen\Contract\Generator\GeneratorInterface;
+use ApiGen\Reflection\ReflectionStorage;
+use ApiGen\Templating\TemplateRenderer;
+
+final class ExceptionsGenerator implements GeneratorInterface
+{
+    /**
+     * @var string
+     */
+    private const NAME = 'exceptions';
+
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * @var TemplateRenderer
+     */
+    private $templateRenderer;
+
+    /**
+     * @var ReflectionStorage
+     */
+    private $reflectionStorage;
+
+    public function __construct(
+        ReflectionStorage $reflectionStorage,
+        Configuration $configuration,
+        TemplateRenderer $templateRenderer
+    ) {
+        $this->configuration = $configuration;
+        $this->templateRenderer = $templateRenderer;
+        $this->reflectionStorage = $reflectionStorage;
+    }
+
+    public function generate(): void
+    {
+        if (count($this->reflectionStorage->getExceptionReflections()) < 1) {
+            return;
+        }
+
+        $this->templateRenderer->renderToFile(
+            $this->configuration->getTemplateByName(self::NAME),
+            $this->configuration->getDestinationWithName(self::NAME),
+            [
+                'activePage' => self::NAME,
+                'pageTitle' => ucfirst(self::NAME),
+                self::NAME => $this->reflectionStorage->getExceptionReflections()
+            ]
+        );
+    }
+}

--- a/src/Generator/NamespaceGenerator.php
+++ b/src/Generator/NamespaceGenerator.php
@@ -55,6 +55,7 @@ final class NamespaceGenerator implements GeneratorInterface
                 'activeNamespace' => $namespace,
                 'childNamespaces' => $this->resolveChildNamespaces($namespace),
                 'classes' => $namespaceReflectionCollector->getClassReflections($namespace),
+                'exceptions' => $namespaceReflectionCollector->getExceptionReflections($namespace),
                 'interfaces' => $namespaceReflectionCollector->getInterfaceReflections($namespace),
                 'traits' => $namespaceReflectionCollector->getTraitReflections($namespace),
                 'functions' => $namespaceReflectionCollector->getFunctionReflections($namespace)

--- a/tests/Generator/ExceptionGeneratorTest.php
+++ b/tests/Generator/ExceptionGeneratorTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Tests\Generator;
+
+use ApiGen\Generator\ExceptionGenerator;
+use ApiGen\Reflection\Parser\Parser;
+use ApiGen\Tests\AbstractContainerAwareTestCase;
+
+final class ExceptionGeneratorTest extends AbstractContainerAwareTestCase
+{
+    /**
+     * @var ExceptionGenerator
+     */
+    private $exceptionElementGenerator;
+
+    protected function setUp(): void
+    {
+        /** @var Parser $parser */
+        $parser = $this->container->get(Parser::class);
+        $parser->parseDirectories([__DIR__ . '/Source']);
+
+        $this->exceptionElementGenerator = $this->container->get(ExceptionGenerator::class);
+    }
+
+    public function testGenerate(): void
+    {
+        $this->exceptionElementGenerator->generate();
+
+        $this->assertFileExists(
+            TEMP_DIR . '/exception-ApiGen.Tests.Generator.Source.SomeException.html'
+        );
+        $this->assertFileExists(
+            TEMP_DIR . '/source-exception-ApiGen.Tests.Generator.Source.SomeException.html'
+        );
+    }
+}

--- a/tests/Generator/ExceptionsGeneratorTest.php
+++ b/tests/Generator/ExceptionsGeneratorTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Tests\Generator;
+
+use ApiGen\Generator\ExceptionsGenerator;
+use ApiGen\Reflection\Parser\Parser;
+use ApiGen\Tests\AbstractContainerAwareTestCase;
+
+final class ExceptionsGeneratorTest extends AbstractContainerAwareTestCase
+{
+    public function test(): void
+    {
+        /** @var Parser $parser */
+        $parser = $this->container->get(Parser::class);
+        $parser->parseDirectories([__DIR__ . '/Source']);
+
+        /** @var ExceptionsGenerator $exceptionsGenerator */
+        $exceptionsGenerator = $this->container->get(ExceptionsGenerator::class);
+        $exceptionsGenerator->generate();
+
+        $this->assertFileExists(TEMP_DIR . '/exceptions.html');
+    }
+}

--- a/tests/Generator/Source/SomeException.php
+++ b/tests/Generator/Source/SomeException.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Tests\Generator\Source;
+
+class SomeException extends \Exception
+{
+
+}


### PR DESCRIPTION
In older ApiGen, there were classes and exceptions summaries separated.

## Before:
![before](https://user-images.githubusercontent.com/22521379/27759704-7040a274-5e37-11e7-85f7-3be678a8dcdf.png)

## After
![after](https://user-images.githubusercontent.com/22521379/27759706-7a692582-5e37-11e7-9cc7-64bb2916727d.png)
