### PR TITLE
fixed console progressbar

### DIFF
--- a/src/Console/Progress/StepCounter.php
+++ b/src/Console/Progress/StepCounter.php
@@ -2,6 +2,7 @@
 
 namespace ApiGen\Console\Progress;
 
+use ApiGen\Element\Namespace_\ParentEmptyNamespacesResolver;
 use ApiGen\Element\ReflectionCollector\NamespaceReflectionCollector;
 use ApiGen\Reflection\ReflectionStorage;
 
@@ -17,17 +18,29 @@ final class StepCounter
      */
     private $namespaceReflectionCollector;
 
+    /**
+     * @var ParentEmptyNamespacesResolver
+     */
+    private $parentEmptyNamespacesResolver;
+
     public function __construct(
         ReflectionStorage $reflectionStorage,
-        NamespaceReflectionCollector $namespaceReflectionCollector
+        NamespaceReflectionCollector $namespaceReflectionCollector,
+        ParentEmptyNamespacesResolver $parentEmptyNamespacesResolver
     ) {
         $this->reflectionStorage = $reflectionStorage;
         $this->namespaceReflectionCollector = $namespaceReflectionCollector;
+        $this->parentEmptyNamespacesResolver = $parentEmptyNamespacesResolver;
     }
 
     public function getStepCount(): int
     {
+        $parentEmptyNamespaces = $this->parentEmptyNamespacesResolver->resolve(
+            $this->namespaceReflectionCollector->getNamespaces()
+        );
+
         return $this->getSourceCodeStepCount()
+            + count($parentEmptyNamespaces)
             + count($this->namespaceReflectionCollector->getNamespaces())
             + count($this->reflectionStorage->getClassReflections())
             + count($this->reflectionStorage->getExceptionReflections())

--- a/tests/Console/Progress/Source/SomeClass.php
+++ b/tests/Console/Progress/Source/SomeClass.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace EmptyNamespace\MyNamespace;
+
+class SomeClass
+{
+
+}

--- a/tests/Console/Progress/Source/SomeException.php
+++ b/tests/Console/Progress/Source/SomeException.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace EmptyNamespace\MyNamespace;
+
+use Exception;
+
+class SomeException extends Exception
+{
+
+}

--- a/tests/Console/Progress/Source/SomeFunction.php
+++ b/tests/Console/Progress/Source/SomeFunction.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace EmptyNamespace\MyNamespace;
+
+function SomeFunction()
+{
+
+}

--- a/tests/Console/Progress/Source/SomeInterface.php
+++ b/tests/Console/Progress/Source/SomeInterface.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace EmptyNamespace\MyNamespace;
+
+interface SomeInterface
+{
+
+}

--- a/tests/Console/Progress/Source/SomeTrait.php
+++ b/tests/Console/Progress/Source/SomeTrait.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace EmptyNamespace\MyNamespace;
+
+trait SomeTrait
+{
+
+}

--- a/tests/Console/Progress/StepCounterTest.php
+++ b/tests/Console/Progress/StepCounterTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Tests\Console\Helper;
+
+use ApiGen\Console\Progress\StepCounter;
+use ApiGen\Element\Namespace_\ParentEmptyNamespacesResolver;
+use ApiGen\Element\ReflectionCollector\NamespaceReflectionCollector;
+use ApiGen\Reflection\Parser\Parser;
+use ApiGen\Tests\AbstractParserAwareTestCase;
+
+final class StepCounterTest extends AbstractParserAwareTestCase
+{
+    public function testStepCount(): void
+    {
+        $this->parser->parseDirectories([__DIR__ . '/Source']);
+        $namespaceReflectionCollector = $this->container->get(NamespaceReflectionCollector::class);
+
+        $stepCounter = new StepCounter(
+            $this->reflectionStorage,
+            $namespaceReflectionCollector,
+            new ParentEmptyNamespacesResolver()
+        );
+
+        $count = 2;    // index.html + elementlist.js
+        $count += 5;   // classes.html + exceptions.html + interfaces.html + traits.html + functions.html
+        $count += 10;  // class, exception, interface, trait and function + their sources
+        $count ++;     // EmptyNamespace
+        $count ++;     // MyNamespace
+
+        $this->assertSame($count, $stepCounter->getStepCount());
+    }
+}


### PR DESCRIPTION
I hope this is fixed for good. It was caused by empty parent namespaces - at least I know what the `EmptyNamespaceGenerator` is for :laughing: 