### PR TITLE
strike out deprecated classes, interfaces, etc. in the main summaries

### DIFF
--- a/packages/ThemeDefault/src/classes.latte
+++ b/packages/ThemeDefault/src/classes.latte
@@ -9,7 +9,7 @@
         {foreach $classes as $class}
             <tr>
                 <td class="name">
-                    <a href="{$class|linkReflection}">{$class->getName()}</a>
+                    <a href="{$class|linkReflection}" n:class="$class->isDeprecated() ? deprecated">{$class->getName()}</a>
                 </td>
             </tr>
         {/foreach}

--- a/packages/ThemeDefault/src/exceptions.latte
+++ b/packages/ThemeDefault/src/exceptions.latte
@@ -9,7 +9,7 @@
         {foreach $exceptions as $exception}
             <tr>
                 <td class="name">
-                    <a href="{$exception|linkReflection}">{$exception->getName()}</a>
+                    <a href="{$exception|linkReflection}" n:class="$exception->isDeprecated() ? deprecated">{$exception->getName()}</a>
                 </td>
             </tr>
         {/foreach}

--- a/packages/ThemeDefault/src/functions.latte
+++ b/packages/ThemeDefault/src/functions.latte
@@ -9,7 +9,7 @@
         {foreach $functions as $function}
             <tr>
                 <td class="name">
-                    <a href="{$function|linkReflection}">{$function->getName()}</a>
+                    <a href="{$function|linkReflection}" n:class="$function->isDeprecated() ? deprecated">{$function->getName()}</a>
                 </td>
             </tr>
         {/foreach}

--- a/packages/ThemeDefault/src/interfaces.latte
+++ b/packages/ThemeDefault/src/interfaces.latte
@@ -9,7 +9,7 @@
         {foreach $interfaces as $interface}
             <tr>
                 <td class="name">
-                    <a href="{$interface|linkReflection}">{$interface->getName()}</a>
+                    <a href="{$interface|linkReflection}" n:class="$interface->isDeprecated() ? deprecated">{$interface->getName()}</a>
                 </td>
             </tr>
         {/foreach}

--- a/packages/ThemeDefault/src/traits.latte
+++ b/packages/ThemeDefault/src/traits.latte
@@ -9,7 +9,7 @@
         {foreach $traits as $trait}
             <tr>
                 <td class="name">
-                    <a href="{$trait|linkReflection}">{$trait->getName()}</a>
+                    <a href="{$trait|linkReflection}" n:class="$trait->isDeprecated() ? deprecated">{$trait->getName()}</a>
                 </td>
             </tr>
         {/foreach}


### PR DESCRIPTION
In namespace summary it is already striked out, in the main summaries it was not.

![deprecated](https://user-images.githubusercontent.com/22521379/27984263-ca593c72-63d1-11e7-8aaa-026b8e4c7328.png)
