### PR TITLE
fixed improper parent class retrieval

### DIFF
--- a/packages/Reflection/src/Reflection/Class_/ClassReflection.php
+++ b/packages/Reflection/src/Reflection/Class_/ClassReflection.php
@@ -128,13 +128,13 @@ final class ClassReflection implements ClassReflectionInterface, TransformerColl
 
     public function getParentClass(): ?ClassReflectionInterface
     {
-        $parentClassName = get_parent_class($this->getName());
-        if ($parentClassName === false) {
+        $parentClassName = $this->getParentClassName();
+        if ($parentClassName === '') {
             return null;
         }
 
         return $this->transformerCollector->transformSingle(
-            ReflectionClass::createFromName($parentClassName)
+            $this->betterClassReflection->getParentClass()
         );
     }
 


### PR DESCRIPTION
I think it is caused by autoload. `get_parent_class()` does not know where to autoload parent classes.
Without the fix, my test class

```php
class XXX extends DifferentVendor1\DifferentClass {
}
```


was rendered like this:
![screenshot](https://user-images.githubusercontent.com/22521379/27986312-ff56032a-63fd-11e7-9e9a-7ea137508ecd.png)

and that is wrong, it should be:

![screenshot-1](https://user-images.githubusercontent.com/22521379/27986314-076c2fbc-63fe-11e7-85d5-63fcd20ef407.png)

