### PR TITLE
:art: Minor improvement in 'finished' msg.

### DIFF
--- a/src/Console/Helper/ProgressBar.php
+++ b/src/Console/Helper/ProgressBar.php
@@ -42,7 +42,7 @@ final class ProgressBar
 
         $this->bar->advance($increment);
         if ($this->bar->getProgress() === $this->bar->getMaxSteps()) {
-            $this->output->writeln(' - Finished!');
+            $this->output->writeln(' - <info>Finished!</info>');
         }
     }
 }


### PR DESCRIPTION
Use `info` context colour for `Finished!`, like you can see in https://travis-ci.org/ApiGen/ApiGen/builds/251577795#L727 log (in line 728).