### PR TITLE
Fixed link generation for type hints.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
             "packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/Source/functionWithConstant.php",
             "packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/Source/functionWithVariadic.php",
             "packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/Source/functionWithClass.php",
+            "packages/StringRouting/tests/Latte/Filter/Source/TestClass.php",
             "packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/SomeClassWithSeeAnnotations.php"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,6 @@
             "packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/Source/functionWithConstant.php",
             "packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/Source/functionWithVariadic.php",
             "packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/Source/functionWithClass.php",
-            "packages/StringRouting/tests/Latte/Filter/Source/TestClass.php",
             "packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/SomeClassWithSeeAnnotations.php"
         ]
     },

--- a/packages/Reflection/src/Contract/Reflection/AbstractParameterReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/AbstractParameterReflectionInterface.php
@@ -2,9 +2,6 @@
 
 namespace ApiGen\Reflection\Contract\Reflection;
 
-use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
-use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterface;
-
 interface AbstractParameterReflectionInterface extends AbstractReflectionInterface
 {
     public function getTypeHint(): string;

--- a/packages/Reflection/src/Contract/Reflection/AbstractParameterReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/AbstractParameterReflectionInterface.php
@@ -9,11 +9,6 @@ interface AbstractParameterReflectionInterface extends AbstractReflectionInterfa
 {
     public function getTypeHint(): string;
 
-    /**
-     * @return ClassReflectionInterface|InterfaceReflectionInterface|null
-     */
-    public function getTypeHintClassOrInterfaceReflection();
-
     public function isDefaultValueAvailable(): bool;
 
     public function getDefaultValueDefinition(): ?string;

--- a/packages/Reflection/src/Contract/Reflection/Class_/ClassPropertyReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Class_/ClassPropertyReflectionInterface.php
@@ -25,9 +25,4 @@ interface ClassPropertyReflectionInterface extends AbstractClassElementInterface
     public function getName(): string;
 
     public function isDeprecated(): bool;
-
-    /**
-     * @return ClassReflectionInterface|InterfaceReflectionInterface|null
-     */
-    public function getTypeHintClassOrInterfaceReflection();
 }

--- a/packages/Reflection/src/Contract/Reflection/Class_/ClassPropertyReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Class_/ClassPropertyReflectionInterface.php
@@ -2,7 +2,6 @@
 
 namespace ApiGen\Reflection\Contract\Reflection\Class_;
 
-use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\AnnotationsInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\StartAndEndLineInterface;
 

--- a/packages/Reflection/src/Contract/Reflection/Trait_/TraitPropertyReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Trait_/TraitPropertyReflectionInterface.php
@@ -23,9 +23,4 @@ interface TraitPropertyReflectionInterface extends AbstractTraitElementInterface
     public function getTypeHint(): string;
 
     public function getNamespaceName(): string;
-
-    /**
-     * @return ClassReflectionInterface|InterfaceReflectionInterface|null
-     */
-    public function getTypeHintClassOrInterfaceReflection();
 }

--- a/packages/Reflection/src/Contract/Reflection/Trait_/TraitPropertyReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Trait_/TraitPropertyReflectionInterface.php
@@ -2,8 +2,6 @@
 
 namespace ApiGen\Reflection\Contract\Reflection\Trait_;
 
-use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
-use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\AccessLevelInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\AnnotationsInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\StartAndEndLineInterface;

--- a/packages/Reflection/src/Reflection/AbstractParameterReflection.php
+++ b/packages/Reflection/src/Reflection/AbstractParameterReflection.php
@@ -5,16 +5,13 @@ namespace ApiGen\Reflection\Reflection;
 use ApiGen\Annotation\AnnotationList;
 use ApiGen\Reflection\Contract\Reflection\AbstractParameterReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassMethodReflectionInterface;
-use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Function_\FunctionParameterReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Function_\FunctionReflectionInterface;
-use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Method\MethodParameterReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Trait_\TraitMethodReflectionInterface;
 use ApiGen\Reflection\Contract\TransformerCollectorAwareInterface;
 use ApiGen\Reflection\TransformerCollector;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
-use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionParameter;
 
 abstract class AbstractParameterReflection implements AbstractParameterReflectionInterface,

--- a/packages/Reflection/src/Reflection/AbstractParameterReflection.php
+++ b/packages/Reflection/src/Reflection/AbstractParameterReflection.php
@@ -51,23 +51,6 @@ abstract class AbstractParameterReflection implements AbstractParameterReflectio
         return '';
     }
 
-    /**
-     * @return ClassReflectionInterface|InterfaceReflectionInterface|null
-     */
-    public function getTypeHintClassOrInterfaceReflection()
-    {
-        if (! class_exists($this->getTypeHint())) {
-            return null;
-        }
-
-        $betterClassReflection = ReflectionClass::createFromName($this->getTypeHint());
-
-        /** @var ClassReflectionInterface|InterfaceReflectionInterface $classOrInterfaceReflection */
-        $classOrInterfaceReflection = $this->transformerCollector->transformSingle($betterClassReflection);
-
-        return $classOrInterfaceReflection;
-    }
-
     public function isDefaultValueAvailable(): bool
     {
         return $this->betterParameterReflection->isDefaultValueAvailable();

--- a/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
+++ b/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
@@ -105,23 +105,6 @@ final class ClassPropertyReflection implements ClassPropertyReflectionInterface,
     }
 
     /**
-     * @return ClassReflectionInterface|InterfaceReflectionInterface|null
-     */
-    public function getTypeHintClassOrInterfaceReflection()
-    {
-        if (! class_exists($this->getTypeHint())) {
-            return null;
-        }
-
-        $betterClassReflection = ReflectionClass::createFromName($this->getTypeHint());
-
-        /** @var ClassReflectionInterface|InterfaceReflectionInterface $classOrInterfaceReflection */
-        $classOrInterfaceReflection = $this->transformerCollector->transformSingle($betterClassReflection);
-
-        return $classOrInterfaceReflection;
-    }
-
-    /**
      * @return mixed[]
      */
     public function getAnnotations(): array

--- a/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
+++ b/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
@@ -5,12 +5,10 @@ namespace ApiGen\Reflection\Reflection\Class_;
 use ApiGen\Annotation\AnnotationList;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassPropertyReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
-use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterface;
 use ApiGen\Reflection\Contract\TransformerCollectorAwareInterface;
 use ApiGen\Reflection\TransformerCollector;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\Types\Object_;
-use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 
 final class ClassPropertyReflection implements ClassPropertyReflectionInterface, TransformerCollectorAwareInterface

--- a/packages/Reflection/src/Reflection/Trait_/TraitPropertyReflection.php
+++ b/packages/Reflection/src/Reflection/Trait_/TraitPropertyReflection.php
@@ -170,21 +170,4 @@ final class TraitPropertyReflection implements TraitPropertyReflectionInterface,
     {
         $this->transformerCollector = $transformerCollector;
     }
-
-    /**
-     * @return ClassReflectionInterface|InterfaceReflectionInterface|null
-     */
-    public function getTypeHintClassOrInterfaceReflection()
-    {
-        if (! class_exists($this->getTypeHint())) {
-            return null;
-        }
-
-        $betterClassReflection = ReflectionClass::createFromName($this->getTypeHint());
-
-        /** @var ClassReflectionInterface|InterfaceReflectionInterface $classOrInterfaceReflection */
-        $classOrInterfaceReflection = $this->transformerCollector->transformSingle($betterClassReflection);
-
-        return $classOrInterfaceReflection;
-    }
 }

--- a/packages/Reflection/src/Reflection/Trait_/TraitPropertyReflection.php
+++ b/packages/Reflection/src/Reflection/Trait_/TraitPropertyReflection.php
@@ -3,8 +3,6 @@
 namespace ApiGen\Reflection\Reflection\Trait_;
 
 use ApiGen\Annotation\AnnotationList;
-use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
-use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Trait_\TraitPropertyReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Trait_\TraitReflectionInterface;
 use ApiGen\Reflection\Contract\TransformerCollectorAwareInterface;
@@ -12,7 +10,6 @@ use ApiGen\Reflection\TransformerCollector;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\Types\Object_;
-use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 
 final class TraitPropertyReflection implements TraitPropertyReflectionInterface, TransformerCollectorAwareInterface

--- a/packages/Reflection/src/ReflectionStorage.php
+++ b/packages/Reflection/src/ReflectionStorage.php
@@ -131,4 +131,23 @@ final class ReflectionStorage
             $this->functionReflections[$functionReflection->getName()] = $functionReflection;
         }
     }
+
+    public function getClass(string $name): ?ClassReflectionInterface
+    {
+        return $this->classReflections[$name] ?? $this->exceptionReflections[$name] ?? null;
+    }
+
+    public function getInterface(string $name): ?InterfaceReflectionInterface
+    {
+        return $this->interfaceReflections[$name] ?? null;
+    }
+
+    /**
+     * @return ClassReflectionInterface|InterfaceReflectionInterface|null
+     */
+    public function getClassOrInterface(string $name)
+    {
+        $class = $this->getClass($name);
+        return $class ?: $this->getInterface($name);
+    }
 }

--- a/packages/Reflection/tests/Reflection/Class_/ClassPropertyReflection/ClassTypeHintPropertyTest.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassPropertyReflection/ClassTypeHintPropertyTest.php
@@ -3,7 +3,6 @@
 namespace ApiGen\Reflection\Tests\Reflection\Class_\ClassPropertyReflection;
 
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassPropertyReflectionInterface;
-use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
 use ApiGen\Reflection\Tests\Reflection\Class_\ClassPropertyReflection\Source\PropertyOfClassType;
 use ApiGen\Reflection\Tests\Reflection\Class_\ClassPropertyReflection\Source\ReflectionProperty;
 use ApiGen\Tests\AbstractParserAwareTestCase;
@@ -28,9 +27,7 @@ final class ClassTypeHintPropertyTest extends AbstractParserAwareTestCase
     {
         $this->assertSame(PropertyOfClassType::class, $this->propertyReflection->getTypeHint());
 
-        $typeHintReflection = $this->propertyReflection->getTypeHintClassOrInterfaceReflection();
-        $this->assertInstanceOf(ClassReflectionInterface::class, $typeHintReflection);
-
-        $this->assertSame(PropertyOfClassType::class, $typeHintReflection->getName());
+        $typeHint = $this->propertyReflection->getTypeHint();
+        $this->assertSame(PropertyOfClassType::class, $typeHint);
     }
 }

--- a/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/ClassTypeTest.php
+++ b/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/ClassTypeTest.php
@@ -2,7 +2,6 @@
 
 namespace ApiGen\Reflection\Tests\Reflection\Function_\FunctionParameterReflection;
 
-use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Function_\FunctionParameterReflectionInterface;
 use ApiGen\Tests\AbstractParserAwareTestCase;
 
@@ -31,9 +30,5 @@ final class ClassTypeTest extends AbstractParserAwareTestCase
     public function testType(): void
     {
         $this->assertSame('SplFileInfo', $this->functionParameterReflection->getTypeHint());
-        $this->assertInstanceOf(
-            ClassReflectionInterface::class,
-            $this->functionParameterReflection->getTypeHintClassOrInterfaceReflection()
-        );
     }
 }

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/ClassParameterReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/ClassParameterReflectionTest.php
@@ -33,9 +33,5 @@ final class ClassParameterReflectionTest extends AbstractParserAwareTestCase
     public function testGetTypeHint(): void
     {
         $this->assertSame(ParameterClass::class, $this->parameterReflection->getTypeHint());
-        $this->assertInstanceOf(
-            ClassReflectionInterface::class,
-            $this->parameterReflection->getTypeHintClassOrInterfaceReflection()
-        );
     }
 }

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/MethodParameterReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/MethodParameterReflectionTest.php
@@ -51,11 +51,6 @@ final class MethodParameterReflectionTest extends AbstractParserAwareTestCase
         $this->assertFalse($this->parameterReflection->isVariadic());
     }
 
-    public function testGetClass(): void
-    {
-        $this->assertNull($this->parameterReflection->getTypeHintClassOrInterfaceReflection());
-    }
-
     public function testGetDeclaringFunction(): void
     {
         $this->assertInstanceOf(

--- a/packages/StringRouting/src/Latte/Filter/StringRoutingFiltersProvider.php
+++ b/packages/StringRouting/src/Latte/Filter/StringRoutingFiltersProvider.php
@@ -58,7 +58,7 @@ final class StringRoutingFiltersProvider implements FilterProviderInterface
                 $reflection = $this->reflectionStorage->getClassOrInterface($className);
                 if ($reflection) {
                     $link = Html::el('a');
-                    $link->href = $this->router->buildRoute(ReflectionRoute::NAME, $reflection);
+                    $link->setAttribute('href', $this->router->buildRoute(ReflectionRoute::NAME, $reflection));
                     $link->setText($className);
                     return $link;
                 } else {

--- a/packages/StringRouting/src/Latte/Filter/StringRoutingFiltersProvider.php
+++ b/packages/StringRouting/src/Latte/Filter/StringRoutingFiltersProvider.php
@@ -4,11 +4,13 @@ namespace ApiGen\StringRouting\Latte\Filter;
 
 use ApiGen\Contract\Templating\FilterProviderInterface;
 use ApiGen\Reflection\Contract\Reflection\AbstractReflectionInterface;
+use ApiGen\Reflection\ReflectionStorage;
 use ApiGen\StringRouting\Route\NamespaceRoute;
 use ApiGen\StringRouting\Route\ReflectionRoute;
 use ApiGen\StringRouting\Route\SourceCodeRoute;
 use ApiGen\StringRouting\StringRouter;
 use Nette\InvalidArgumentException;
+use Nette\Utils\Html;
 
 final class StringRoutingFiltersProvider implements FilterProviderInterface
 {
@@ -17,9 +19,15 @@ final class StringRoutingFiltersProvider implements FilterProviderInterface
      */
     private $router;
 
-    public function __construct(StringRouter $router)
+    /**
+     * @var ReflectionStorage
+     */
+    private $reflectionStorage;
+
+    public function __construct(StringRouter $router, ReflectionStorage $reflectionStorage)
     {
         $this->router = $router;
+        $this->reflectionStorage = $reflectionStorage;
     }
 
     /**
@@ -43,6 +51,19 @@ final class StringRoutingFiltersProvider implements FilterProviderInterface
             'linkSource' => function ($reflection): string {
                 $this->ensureFilterArgumentsIsReflection($reflection, 'linkSource');
                 return $this->router->buildRoute(SourceCodeRoute::NAME, $reflection);
+            },
+
+            // use in .latte: {$className|buildLinkIfReflectionFound}
+            'buildLinkIfReflectionFound' => function (string $className) {
+                $reflection = $this->reflectionStorage->getClassOrInterface($className);
+                if ($reflection) {
+                    $link = Html::el('a');
+                    $link->href = $this->router->buildRoute(ReflectionRoute::NAME, $reflection);
+                    $link->setText($className);
+                    return $link;
+                } else {
+                    return $className;
+                }
             }
         ];
     }

--- a/packages/StringRouting/tests/Latte/Filter/LinkFilterTest.php
+++ b/packages/StringRouting/tests/Latte/Filter/LinkFilterTest.php
@@ -4,6 +4,7 @@ namespace ApiGen\StringRouting\Tests\Latte\Filter;
 
 use ApiGen\Reflection\Parser\Parser;
 use ApiGen\Reflection\ReflectionStorage;
+use ApiGen\StringRouting\Tests\Latte\Filter\Source\TestClass;
 use ApiGen\Tests\AbstractContainerAwareTestCase;
 use Latte\Engine;
 use Nette\InvalidArgumentException;
@@ -40,9 +41,12 @@ final class LinkFilterTest extends AbstractContainerAwareTestCase
         $reflectionStorage = $this->container->get(ReflectionStorage::class);
 
         $html = $this->latte->renderToString(__DIR__ . '/Source/buildLinkIfReflectionFound-template.latte', [
-            'className' => 'TestNamespace\TestClass',
+            'className' => TestClass::class,
         ]);
-        $this->assertSame('<a href="class-TestNamespace.TestClass.html">TestNamespace\TestClass</a>', trim($html));
+        $this->assertSame(
+            '<a href="class-ApiGen.StringRouting.Tests.Latte.Filter.Source.TestClass.html">'. TestClass::class . '</a>',
+            trim($html)
+        );
 
         $html = $this->latte->renderToString(__DIR__ . '/Source/buildLinkIfReflectionFound-template.latte', [
             'className' => 'string',

--- a/packages/StringRouting/tests/Latte/Filter/LinkFilterTest.php
+++ b/packages/StringRouting/tests/Latte/Filter/LinkFilterTest.php
@@ -2,6 +2,8 @@
 
 namespace ApiGen\StringRouting\Tests\Latte\Filter;
 
+use ApiGen\Reflection\Parser\Parser;
+use ApiGen\Reflection\ReflectionStorage;
 use ApiGen\Tests\AbstractContainerAwareTestCase;
 use Latte\Engine;
 use Nette\InvalidArgumentException;
@@ -29,5 +31,22 @@ final class LinkFilterTest extends AbstractContainerAwareTestCase
         $this->latte->renderToString(__DIR__ . '/Source/template.latte', [
             'classReflection' => 'SomeClass'
         ]);
+    }
+
+    public function testBuildLinkIfReflectionFoundFilter(): void
+    {
+        $parser = $this->container->get(Parser::class);
+        $parser->parseFilesAndDirectories([__DIR__ . '/Source/TestClass.php']);
+        $reflectionStorage = $this->container->get(ReflectionStorage::class);
+
+        $html = $this->latte->renderToString(__DIR__ . '/Source/buildLinkIfReflectionFound-template.latte', [
+            'className' => 'TestNamespace\TestClass',
+        ]);
+        $this->assertSame('<a href="class-TestNamespace.TestClass.html">TestNamespace\TestClass</a>', trim($html));
+
+        $html = $this->latte->renderToString(__DIR__ . '/Source/buildLinkIfReflectionFound-template.latte', [
+            'className' => 'string',
+        ]);
+        $this->assertSame('string', trim($html));
     }
 }

--- a/packages/StringRouting/tests/Latte/Filter/Source/TestClass.php
+++ b/packages/StringRouting/tests/Latte/Filter/Source/TestClass.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace TestNamespace;
+
+class TestClass
+{
+}

--- a/packages/StringRouting/tests/Latte/Filter/Source/TestClass.php
+++ b/packages/StringRouting/tests/Latte/Filter/Source/TestClass.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace TestNamespace;
+namespace ApiGen\StringRouting\Tests\Latte\Filter\Source;
 
 class TestClass
 {

--- a/packages/StringRouting/tests/Latte/Filter/Source/buildLinkIfReflectionFound-template.latte
+++ b/packages/StringRouting/tests/Latte/Filter/Source/buildLinkIfReflectionFound-template.latte
@@ -1,0 +1,1 @@
+{$className|buildLinkIfReflectionFound}

--- a/packages/ThemeDefault/src/function.latte
+++ b/packages/ThemeDefault/src/function.latte
@@ -40,11 +40,7 @@
             <tr n:foreach="$function->getParameters() as $parameter" id="${$parameter->getName()}">
                 <td class="name">
                     <code>
-                        {if $parameter->getTypeHintClassOrInterfaceReflection()}
-                            {$parameter->getTypeHintClassOrInterfaceReflection()|linkReflection}
-                        {else}
-                            {$parameter->getTypeHint()}
-                        {/if}
+                        {$parameter->getTypeHint()|buildLinkIfReflectionFound}
                     </code>
                 </td>
                 <td class="value"><code>{block|strip}

--- a/packages/ThemeDefault/src/partial/method.latte
+++ b/packages/ThemeDefault/src/partial/method.latte
@@ -24,11 +24,7 @@
                     <a href="{$method|linkSource}">{$method->getName()}</a>(
                     {foreach $method->getParameters() as $parameter}
                         <span>
-                            {if $parameter->getTypeHintClassOrInterfaceReflection()}
-                                <a href="{$parameter->getTypeHintClassOrInterfaceReflection()|linkReflection}">{$parameter->getTypeHint()}</a>
-                            {else}
-                                {$parameter->getTypeHint()}
-                            {/if}
+                            {$parameter->getTypeHint()|buildLinkIfReflectionFound}
                             <span class="property-name">{if $parameter->isPassedByReference()}&amp; {/if}${$parameter->getName()}</span>
 
                         {if $parameter->getDefaultValueDefinition()} = {$parameter->getDefaultValueDefinition()|phpHighlight|noescape}{elseif $parameter->isVariadic()},…{/if}</span>{sep}, {/sep}

--- a/packages/ThemeDefault/src/partial/property.latte
+++ b/packages/ThemeDefault/src/partial/property.latte
@@ -3,11 +3,7 @@
         <code class="keyword">
             {if $property->isProtected()}protected{elseif $property->isPrivate()}private{else}public{/if} {if $property->isStatic()}static{/if}
 
-            {if $property->getTypeHintClassOrInterfaceReflection()}
-                {$property->getTypeHintClassOrInterfaceReflection()|linkReflection}
-            {else}
-                {$property->getTypeHint()}
-            {/if}
+            {$property->getTypeHint()|buildLinkIfReflectionFound}
         </code>
     </td>
 


### PR DESCRIPTION
I just have started to work on the function return types I promised. But I have found another issue that is connected to it.

There was a problem that functions `getTypeHintClassOrInterfaceReflection()` relied on `class_exists()`. But it could happen that the class is not autoloaded before BetterReflection tries to locate it. And that is problem: for classes that were not located yet, it is going to fail. And for internal PHP classes it is going to work and generate a link to page that will not be generated.

I think that it would be better to check existence of the class it in the `ReflectionStorage` directly. I do not think that is is responsibility of the `ClassReflection` to know about other classes, it should be a matter of `ReflectionStorage`. And also there should be generated only links leading to elements really present in the ReflectionStorage (otherwise it could generate dead links to missing pages) so it is another reason to change it in a way I propose.


Additionally, there was bug with generating links - it printed just the path to the file but not generate a real link.

Originally, it looked like this:
![bad](https://user-images.githubusercontent.com/22521379/28164848-93d6fe2e-67d1-11e7-8ee3-0ae66d36b72f.png)

And after the fixes:
![good](https://user-images.githubusercontent.com/22521379/28164868-a6e7fca2-67d1-11e7-991a-1a418a9a8315.png)

