### PR TITLE
[Reflection] fix @See annotation exception

### DIFF
--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -93,6 +93,9 @@ parameters:
             - packages/ModularConfiguration/src/Option/SourceOption.php
             - packages/ModularConfiguration/src/Option/ThemeDirectoryOption.php
 
+            # extending messy 3rd party code
+            - packages/Reflection/src/DocBlock/Tags/See.php
+
         SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff:
             - packages/Reflection/tests/Reflection/Class_/ClassReflection/Source/AccessLevels.php
 

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -16,7 +16,6 @@ checkers:
 
     # Comments
     - Symplify\CodingStandard\Sniffs\Commenting\BlockPropertyCommentSniff
-    - Symplify\CodingStandard\Sniffs\Commenting\VarPropertyCommentSniff
 
     # Dev & Dead Code
     - Symplify\CodingStandard\Sniffs\Debug\DebugFunctionCallSniff

--- a/packages/Annotation/src/AnnotationSubscriber/LinkAnnotationSubscriber.php
+++ b/packages/Annotation/src/AnnotationSubscriber/LinkAnnotationSubscriber.php
@@ -4,6 +4,7 @@ namespace ApiGen\Annotation\AnnotationSubscriber;
 
 use ApiGen\Annotation\Contract\AnnotationSubscriber\AnnotationSubscriberInterface;
 use ApiGen\Reflection\Contract\Reflection\AbstractReflectionInterface;
+use ApiGen\Reflection\DocBlock\Tags\See;
 use ApiGen\Utils\LinkBuilder;
 use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\DocBlock\Tags\Link;
@@ -25,11 +26,11 @@ final class LinkAnnotationSubscriber implements AnnotationSubscriberInterface
      */
     public function matches($content): bool
     {
-        return $content instanceof Link;
+        return $content instanceof Link || ($content instanceof See && $content->getLink());
     }
 
     /**
-     * @param Link $content
+     * @param Link|See $content
      */
     public function process($content, AbstractReflectionInterface $reflection): string
     {

--- a/packages/Annotation/src/AnnotationSubscriber/SeeUsesCoversAnnotationSubscriber.php
+++ b/packages/Annotation/src/AnnotationSubscriber/SeeUsesCoversAnnotationSubscriber.php
@@ -5,11 +5,11 @@ namespace ApiGen\Annotation\AnnotationSubscriber;
 use ApiGen\Annotation\Contract\AnnotationSubscriber\AnnotationSubscriberInterface;
 use ApiGen\Annotation\FqsenResolver\ElementResolver;
 use ApiGen\Reflection\Contract\Reflection\AbstractReflectionInterface;
+use ApiGen\Reflection\DocBlock\Tags\See;
 use ApiGen\StringRouting\Route\ReflectionRoute;
 use ApiGen\Utils\LinkBuilder;
 use phpDocumentor\Reflection\DocBlock\Tag;
 use phpDocumentor\Reflection\DocBlock\Tags\Covers;
-use phpDocumentor\Reflection\DocBlock\Tags\See;
 use phpDocumentor\Reflection\DocBlock\Tags\Uses;
 use phpDocumentor\Reflection\Fqsen;
 
@@ -44,7 +44,8 @@ final class SeeUsesCoversAnnotationSubscriber implements AnnotationSubscriberInt
      */
     public function matches($content): bool
     {
-        return $content instanceof See || $content instanceof Covers || $content instanceof Uses;
+        return ($content instanceof See && $content->getReference())
+            || $content instanceof Covers || $content instanceof Uses;
     }
 
     /**

--- a/packages/Annotation/tests/AnnotationSubscriber/LinkAnnotationSubscriberSource/SomeClassWithLinkAnnotations.php
+++ b/packages/Annotation/tests/AnnotationSubscriber/LinkAnnotationSubscriberSource/SomeClassWithLinkAnnotations.php
@@ -5,6 +5,7 @@ namespace ApiGen\Annotation\Tests\AnnotationSubscriber\LinkAnnotationSubscriberS
 /**
  * User session storage for PHP < 5.4.
  * @link http://php.net/session_set_save_handler
+ * @see https://github.com/apigen/apigen
  */
 final class SomeClassWithLinkAnnotations
 {

--- a/packages/Annotation/tests/AnnotationSubscriber/LinkAnnotationSubscriberTest.php
+++ b/packages/Annotation/tests/AnnotationSubscriber/LinkAnnotationSubscriberTest.php
@@ -41,6 +41,17 @@ final class LinkAnnotationSubscriberTest extends AbstractParserAwareTestCase
         );
     }
 
+    public function testSeeUrlAnnotation(): void
+    {
+        $seeUrlAnnotation = $this->classReflection->getAnnotation(AnnotationList::SEE)[0];
+        $decoratedAnnotation = $this->annotationDecorator->decorate($seeUrlAnnotation, $this->classReflection);
+
+        $this->assertSame(
+            '<a href="https://github.com/apigen/apigen">https://github.com/apigen/apigen</a>',
+            $decoratedAnnotation
+        );
+    }
+
     /**
      * @dataProvider getLinkAnnotationData()
      */

--- a/packages/Reflection/src/DocBlock/DocBlockFactory.php
+++ b/packages/Reflection/src/DocBlock/DocBlockFactory.php
@@ -7,8 +7,10 @@ use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\DocBlock\TagFactory;
 use phpDocumentor\Reflection\DocBlockFactory as PhpDocumentorDocBlockFactory;
+use phpDocumentor\Reflection\TypeResolver;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
+use Roave\BetterReflection\Reflection\ReflectionProperty;
 
 final class DocBlockFactory
 {
@@ -20,13 +22,15 @@ final class DocBlockFactory
     public function __construct(
         TagFactory $tagFactory,
         PhpDocumentorDocBlockFactory $docBlockFactory,
-        DescriptionFactory $descriptionFactory
+        DescriptionFactory $descriptionFactory,
+        TypeResolver $typeResolver
     ) {
         $this->phpDocumentorDocBlockFactory = $docBlockFactory;
 
         // cannot move to services.yml, because it would cause circular dependency exception
         $tagFactory->registerTagHandler('see', See::class);
         $tagFactory->addService($descriptionFactory);
+        $tagFactory->addService($typeResolver);
     }
 
     /**

--- a/packages/Reflection/src/DocBlock/DocBlockFactory.php
+++ b/packages/Reflection/src/DocBlock/DocBlockFactory.php
@@ -16,26 +16,16 @@ final class DocBlockFactory
      */
     private $phpDocumentorDocBlockFactory;
 
-    /**
-     * @var TagFactory
-     */
-    private $tagFactory;
-
-    /**
-     * @var DescriptionFactory
-     */
-    private $descriptionFactory;
-
-    public function __construct(TagFactory $tagFactory, PhpDocumentorDocBlockFactory $docBlockFactory, DescriptionFactory $descriptionFactory)
-    {
+    public function __construct(
+        TagFactory $tagFactory,
+        PhpDocumentorDocBlockFactory $docBlockFactory,
+        DescriptionFactory $descriptionFactory
+    ) {
         $this->phpDocumentorDocBlockFactory = $docBlockFactory;
-        $this->tagFactory = $tagFactory;
-        $this->descriptionFactory = $descriptionFactory;
 
-        // @todo: move to services.yml
-        $this->tagFactory->registerTagHandler('see', See::class);
-        $this->tagFactory->addService($this->descriptionFactory);
-
+        // cannot move to services.yml, because it would cause circular dependency exception
+        $tagFactory->registerTagHandler('see', See::class);
+        $tagFactory->addService($descriptionFactory);
     }
 
     public function createFromBetterReflection(ReflectionClass $classReflection): DocBlock

--- a/packages/Reflection/src/DocBlock/DocBlockFactory.php
+++ b/packages/Reflection/src/DocBlock/DocBlockFactory.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Reflection\DocBlock;
+
+use ApiGen\Reflection\DocBlock\Tags\See;
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
+use phpDocumentor\Reflection\DocBlock\TagFactory;
+use phpDocumentor\Reflection\DocBlockFactory as PhpDocumentorDocBlockFactory;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+
+final class DocBlockFactory
+{
+    /**
+     * @var PhpDocumentorDocBlockFactory
+     */
+    private $phpDocumentorDocBlockFactory;
+
+    /**
+     * @var TagFactory
+     */
+    private $tagFactory;
+
+    /**
+     * @var DescriptionFactory
+     */
+    private $descriptionFactory;
+
+    public function __construct(TagFactory $tagFactory, PhpDocumentorDocBlockFactory $docBlockFactory, DescriptionFactory $descriptionFactory)
+    {
+        $this->phpDocumentorDocBlockFactory = $docBlockFactory;
+        $this->tagFactory = $tagFactory;
+        $this->descriptionFactory = $descriptionFactory;
+
+        // @todo: move to services.yml
+        $this->tagFactory->registerTagHandler('see', See::class);
+        $this->tagFactory->addService($this->descriptionFactory);
+
+    }
+
+    public function createFromBetterReflection(ReflectionClass $classReflection): DocBlock
+    {
+        return $this->phpDocumentorDocBlockFactory->create($classReflection->getDocComment() ?: ' ');
+    }
+}

--- a/packages/Reflection/src/DocBlock/DocBlockFactory.php
+++ b/packages/Reflection/src/DocBlock/DocBlockFactory.php
@@ -8,6 +8,7 @@ use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\DocBlock\TagFactory;
 use phpDocumentor\Reflection\DocBlockFactory as PhpDocumentorDocBlockFactory;
 use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionMethod;
 
 final class DocBlockFactory
 {
@@ -28,7 +29,10 @@ final class DocBlockFactory
         $tagFactory->addService($descriptionFactory);
     }
 
-    public function createFromBetterReflection(ReflectionClass $classReflection): DocBlock
+    /**
+     * @param ReflectionClass|ReflectionMethod|ReflectionProperty $classReflection
+     */
+    public function createFromBetterReflection($classReflection): DocBlock
     {
         return $this->phpDocumentorDocBlockFactory->create($classReflection->getDocComment() ?: ' ');
     }

--- a/packages/Reflection/src/DocBlock/Tags/See.php
+++ b/packages/Reflection/src/DocBlock/Tags/See.php
@@ -58,7 +58,7 @@ final class See extends BaseTag implements StaticMethod
             $fqsen = null;
         }
 
-        $description =  isset($parts[1]) ? $descriptionFactory->create($parts[1], $context) : null;
+        $description = isset($parts[1]) ? $descriptionFactory->create($parts[1], $context) : null;
 
         return new static($fqsen, $url, $description);
     }

--- a/packages/Reflection/src/DocBlock/Tags/See.php
+++ b/packages/Reflection/src/DocBlock/Tags/See.php
@@ -29,18 +29,16 @@ final class See extends BaseTag implements StaticMethod
      */
     private $url;
 
-    /**
-     * @var DescriptionFactory
-     */
-    private $descriptionFactory;
-
-    public function __construct(Fqsen $refers = null, string $url = null, Description $description = null)
+    public function __construct(?Fqsen $refers = null, ?string $url = null, ?Description $description = null)
     {
         $this->refers = $refers;
         $this->url = $url;
         $this->description = $description;
     }
 
+    /**
+     * @param string $body
+     */
     public static function create(
         $body,
         FqsenResolver $resolver = null,

--- a/packages/Reflection/src/DocBlock/Tags/See.php
+++ b/packages/Reflection/src/DocBlock/Tags/See.php
@@ -27,12 +27,12 @@ final class See extends BaseTag implements StaticMethod
     /**
      * @var string
      */
-    private $url;
+    private $link;
 
-    public function __construct(?Fqsen $refers = null, ?string $url = null, ?Description $description = null)
+    public function __construct(?Fqsen $refers = null, ?string $link = null, ?Description $description = null)
     {
         $this->refers = $refers;
-        $this->url = $url;
+        $this->link = $link;
         $this->description = $description;
     }
 
@@ -50,17 +50,17 @@ final class See extends BaseTag implements StaticMethod
 
         $parts = preg_split('/\s+/Su', $body, 2);
 
-        if (! Validators::isUri($parts[0])) {
+        if (! Validators::isUrl($parts[0])) {
             $fqsen = $resolver->resolve($parts[0], $context);
-            $url = null;
+            $link = null;
         } else {
-            $url = $parts[0];
+            $link = $parts[0];
             $fqsen = null;
         }
 
         $description = isset($parts[1]) ? $descriptionFactory->create($parts[1], $context) : null;
 
-        return new static($fqsen, $url, $description);
+        return new static($fqsen, $link, $description);
     }
 
     public function getReference(): ?Fqsen
@@ -68,13 +68,13 @@ final class See extends BaseTag implements StaticMethod
         return $this->refers;
     }
 
-    public function getUrl(): ?string
+    public function getLink(): ?string
     {
-        return $this->url;
+        return $this->link;
     }
 
     public function __toString(): string
     {
-        return ($this->refers ?: $this->url) . ($this->description ? ' ' . $this->description->render() : '');
+        return ($this->refers ?: $this->link) . ($this->description ? ' ' . $this->description->render() : '');
     }
 }

--- a/packages/Reflection/src/DocBlock/Tags/See.php
+++ b/packages/Reflection/src/DocBlock/Tags/See.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Reflection\DocBlock\Tags;
+
+use Nette\Utils\Validators;
+use phpDocumentor\Reflection\DocBlock\Description;
+use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
+use phpDocumentor\Reflection\DocBlock\Tags\BaseTag;
+use phpDocumentor\Reflection\DocBlock\Tags\Factory\StaticMethod;
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\FqsenResolver;
+use phpDocumentor\Reflection\Types\Context as TypeContext;
+use Webmozart\Assert\Assert;
+
+final class See extends BaseTag implements StaticMethod
+{
+    /**
+     * @var string
+     */
+    protected $name = 'see';
+
+    /**
+     * @var Fqsen
+     */
+    protected $refers;
+
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @var DescriptionFactory
+     */
+    private $descriptionFactory;
+
+    public function __construct(Fqsen $refers = null, string $url = null, Description $description = null)
+    {
+        $this->refers = $refers;
+        $this->url = $url;
+        $this->description = $description;
+    }
+
+    public static function create(
+        $body,
+        FqsenResolver $resolver = null,
+        DescriptionFactory $descriptionFactory = null,
+        TypeContext $context = null
+    ): self {
+        Assert::string($body);
+        Assert::allNotNull([$resolver, $descriptionFactory]);
+
+        $parts = preg_split('/\s+/Su', $body, 2);
+
+        if (! Validators::isUri($parts[0])) {
+            $fqsen = $resolver->resolve($parts[0], $context);
+            $url = null;
+        } else {
+            $url = $parts[0];
+            $fqsen = null;
+        }
+
+        $description =  isset($parts[1]) ? $descriptionFactory->create($parts[1], $context) : null;
+
+        return new static($fqsen, $url, $description);
+    }
+
+    public function getReference(): ?Fqsen
+    {
+        return $this->refers;
+    }
+
+    public function getUrl(): ?string
+    {
+        return $this->url;
+    }
+
+    public function __toString(): string
+    {
+        return ($this->refers ?: $this->url) . ($this->description ? ' ' . $this->description->render() : '');
+    }
+}

--- a/packages/Reflection/src/Transformer/BetterReflection/Class_/ClassMethodReflectionTransformer.php
+++ b/packages/Reflection/src/Transformer/BetterReflection/Class_/ClassMethodReflectionTransformer.php
@@ -4,18 +4,18 @@ namespace ApiGen\Reflection\Transformer\BetterReflection\Class_;
 
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassMethodReflectionInterface;
 use ApiGen\Reflection\Contract\Transformer\TransformerInterface;
+use ApiGen\Reflection\DocBlock\DocBlockFactory;
 use ApiGen\Reflection\Reflection\Class_\ClassMethodReflection;
-use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 
 final class ClassMethodReflectionTransformer implements TransformerInterface
 {
     /**
-     * @var DocBlockFactoryInterface
+     * @var DocBlockFactory
      */
     private $docBlockFactory;
 
-    public function __construct(DocBlockFactoryInterface $docBlockFactory)
+    public function __construct(DocBlockFactory $docBlockFactory)
     {
         $this->docBlockFactory = $docBlockFactory;
     }
@@ -39,8 +39,9 @@ final class ClassMethodReflectionTransformer implements TransformerInterface
      */
     public function transform($reflection): ClassMethodReflectionInterface
     {
-        $docBlock = $this->docBlockFactory->create($reflection->getDocComment() ?: ' ');
-
-        return new ClassMethodReflection($reflection, $docBlock);
+        return new ClassMethodReflection(
+            $reflection,
+            $this->docBlockFactory->createFromBetterReflection($reflection)
+        );
     }
 }

--- a/packages/Reflection/src/Transformer/BetterReflection/Class_/ClassPropertyReflectionTransformer.php
+++ b/packages/Reflection/src/Transformer/BetterReflection/Class_/ClassPropertyReflectionTransformer.php
@@ -4,18 +4,18 @@ namespace ApiGen\Reflection\Transformer\BetterReflection\Class_;
 
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassPropertyReflectionInterface;
 use ApiGen\Reflection\Contract\Transformer\TransformerInterface;
+use ApiGen\Reflection\DocBlock\DocBlockFactory;
 use ApiGen\Reflection\Reflection\Class_\ClassPropertyReflection;
-use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 
 final class ClassPropertyReflectionTransformer implements TransformerInterface
 {
     /**
-     * @var DocBlockFactoryInterface
+     * @var DocBlockFactory
      */
     private $docBlockFactory;
 
-    public function __construct(DocBlockFactoryInterface $docBlockFactory)
+    public function __construct(DocBlockFactory $docBlockFactory)
     {
         $this->docBlockFactory = $docBlockFactory;
     }
@@ -42,8 +42,9 @@ final class ClassPropertyReflectionTransformer implements TransformerInterface
      */
     public function transform($reflection): ClassPropertyReflectionInterface
     {
-        $docBlock = $this->docBlockFactory->create($reflection->getDocComment() ?: ' ');
-
-        return new ClassPropertyReflection($reflection, $docBlock);
+        return new ClassPropertyReflection(
+            $reflection,
+            $this->docBlockFactory->createFromBetterReflection($reflection)
+        );
     }
 }

--- a/packages/Reflection/src/Transformer/BetterReflection/Trait_/TraitMethodReflectionTransformer.php
+++ b/packages/Reflection/src/Transformer/BetterReflection/Trait_/TraitMethodReflectionTransformer.php
@@ -4,18 +4,18 @@ namespace ApiGen\Reflection\Transformer\BetterReflection\Trait_;
 
 use ApiGen\Reflection\Contract\Reflection\Trait_\TraitMethodReflectionInterface;
 use ApiGen\Reflection\Contract\Transformer\TransformerInterface;
+use ApiGen\Reflection\DocBlock\DocBlockFactory;
 use ApiGen\Reflection\Reflection\Trait_\TraitMethodReflection;
-use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 
 final class TraitMethodReflectionTransformer implements TransformerInterface
 {
     /**
-     * @var DocBlockFactoryInterface
+     * @var DocBlockFactory
      */
     private $docBlockFactory;
 
-    public function __construct(DocBlockFactoryInterface $docBlockFactory)
+    public function __construct(DocBlockFactory $docBlockFactory)
     {
         $this->docBlockFactory = $docBlockFactory;
     }
@@ -39,8 +39,9 @@ final class TraitMethodReflectionTransformer implements TransformerInterface
      */
     public function transform($reflection): TraitMethodReflectionInterface
     {
-        $docBlock = $this->docBlockFactory->create($reflection->getDocComment() ?: ' ');
-
-        return new TraitMethodReflection($reflection, $docBlock);
+        return new TraitMethodReflection(
+            $reflection,
+            $this->docBlockFactory->createFromBetterReflection($reflection)
+        );
     }
 }

--- a/packages/Reflection/src/Transformer/BetterReflection/Trait_/TraitPropertyReflectionTransformer.php
+++ b/packages/Reflection/src/Transformer/BetterReflection/Trait_/TraitPropertyReflectionTransformer.php
@@ -4,18 +4,18 @@ namespace ApiGen\Reflection\Transformer\BetterReflection\Trait_;
 
 use ApiGen\Reflection\Contract\Reflection\Trait_\TraitPropertyReflectionInterface;
 use ApiGen\Reflection\Contract\Transformer\TransformerInterface;
+use ApiGen\Reflection\DocBlock\DocBlockFactory;
 use ApiGen\Reflection\Reflection\Trait_\TraitPropertyReflection;
-use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 
 final class TraitPropertyReflectionTransformer implements TransformerInterface
 {
     /**
-     * @var DocBlockFactoryInterface
+     * @var DocBlockFactory
      */
     private $docBlockFactory;
 
-    public function __construct(DocBlockFactoryInterface $docBlockFactory)
+    public function __construct(DocBlockFactory $docBlockFactory)
     {
         $this->docBlockFactory = $docBlockFactory;
     }
@@ -42,8 +42,9 @@ final class TraitPropertyReflectionTransformer implements TransformerInterface
      */
     public function transform($reflection): TraitPropertyReflectionInterface
     {
-        $docBlock = $this->docBlockFactory->create($reflection->getDocComment() ?: ' ');
-
-        return new TraitPropertyReflection($reflection, $docBlock);
+        return new TraitPropertyReflection(
+            $reflection,
+            $this->docBlockFactory->createFromBetterReflection($reflection)
+        );
     }
 }

--- a/packages/Reflection/tests/DocBlock/DocBlockFactorySource/ClassWithSeeAnnotation.php
+++ b/packages/Reflection/tests/DocBlock/DocBlockFactorySource/ClassWithSeeAnnotation.php
@@ -4,6 +4,7 @@ namespace ApiGen\Reflection\Tests\DocBlock\DocBlockFactorySource;
 
 /**
  * @see https://github.com/apigen/apigen
+ * @param int
  */
 final class ClassWithSeeAnnotation
 {

--- a/packages/Reflection/tests/DocBlock/DocBlockFactorySource/ClassWithSeeAnnotation.php
+++ b/packages/Reflection/tests/DocBlock/DocBlockFactorySource/ClassWithSeeAnnotation.php
@@ -7,5 +7,4 @@ namespace ApiGen\Reflection\Tests\DocBlock\DocBlockFactorySource;
  */
 final class ClassWithSeeAnnotation
 {
-
 }

--- a/packages/Reflection/tests/DocBlock/DocBlockFactorySource/ClassWithSeeAnnotation.php
+++ b/packages/Reflection/tests/DocBlock/DocBlockFactorySource/ClassWithSeeAnnotation.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Reflection\Tests\DocBlock\DocBlockFactorySource;
+
+/**
+ * @see https://github.com/apigen/apigen
+ */
+final class ClassWithSeeAnnotation
+{
+
+}

--- a/packages/Reflection/tests/DocBlock/DocBlockFactoryTest.php
+++ b/packages/Reflection/tests/DocBlock/DocBlockFactoryTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Reflection\Tests\DocBlock;
+
+use ApiGen\Reflection\DocBlock\DocBlockFactory;
+use ApiGen\Reflection\Tests\DocBlock\DocBlockFactorySource\ClassWithSeeAnnotation;
+use ApiGen\Tests\AbstractContainerAwareTestCase;
+use phpDocumentor\Reflection\DocBlock;
+use Roave\BetterReflection\Reflection\ReflectionClass;
+
+final class DocBlockFactoryTest extends AbstractContainerAwareTestCase
+{
+    /**
+     * @var DocBlockFactory
+     */
+    private $docBlockFactory;
+
+    protected function setUp(): void
+    {
+        $this->docBlockFactory = $this->container->get(DocBlockFactory::class);
+    }
+
+    public function test(): void
+    {
+        $classWithSeeAnnotation = ReflectionClass::createFromName(ClassWithSeeAnnotation::class);
+
+        $docBlock = $this->docBlockFactory->createFromBetterReflection($classWithSeeAnnotation);
+
+        $this->assertInstanceOf(DocBlock::class, $docBlock);
+
+        $this->assertCount(1, $docBlock->getTagsByName('see'));
+        $this->assertCount(0, $docBlock->getTagsByName('link'));
+    }
+}

--- a/packages/Reflection/tests/DocBlock/DocBlockFactoryTest.php
+++ b/packages/Reflection/tests/DocBlock/DocBlockFactoryTest.php
@@ -30,5 +30,6 @@ final class DocBlockFactoryTest extends AbstractContainerAwareTestCase
 
         $this->assertCount(1, $docBlock->getTagsByName('see'));
         $this->assertCount(0, $docBlock->getTagsByName('link'));
+        $this->assertCount(1, $docBlock->getTagsByName('param'));
     }
 }

--- a/packages/Reflection/tests/Parser/ParserTest.php
+++ b/packages/Reflection/tests/Parser/ParserTest.php
@@ -10,28 +10,6 @@ use ApiGen\Tests\AbstractContainerAwareTestCase;
 
 final class ParserTest extends AbstractContainerAwareTestCase
 {
-    public function testFileSource(): void
-    {
-        $parser = $this->container->get(Parser::class);
-        $reflectionStorage = $this->container->get(ReflectionStorage::class);
-
-        $parser->parseFilesAndDirectories([__DIR__ . '/NotLoadedSources/SomeClass.php']);
-
-        $classReflections = $reflectionStorage->getClassReflections();
-        $this->assertArrayHasKey(SomeClass::class, $classReflections);
-    }
-
-    public function testDirectorySource(): void
-    {
-        $parser = $this->container->get(Parser::class);
-        $reflectionStorage = $this->container->get(ReflectionStorage::class);
-
-        $parser->parseFilesAndDirectories([__DIR__ . '/NotLoadedSources']);
-
-        $classReflections = $reflectionStorage->getClassReflections();
-        $this->assertArrayHasKey(SomeClass::class, $classReflections);
-    }
-
     public function testFilesAndDirectorySource(): void
     {
         $parser = $this->container->get(Parser::class);

--- a/packages/Reflection/tests/Reflection/Class_/ClassMethodReflection/ClassMethodReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassMethodReflection/ClassMethodReflectionTest.php
@@ -29,37 +29,37 @@ final class ClassMethodReflectionTest extends AbstractParserAwareTestCase
         $this->assertSame('methodWithArgs', $this->methodReflection->getName());
     }
 
-//    public function testInstance(): void
-//    {
-//        $this->assertInstanceOf(ClassMethodReflectionInterface::class, $this->methodReflection);
-//    }
-//
-//    public function testGetDeclaringClass(): void
-//    {
-//        $this->assertInstanceOf(ClassReflectionInterface::class, $this->methodReflection->getDeclaringClass());
-//        $this->assertSame(ClassMethod::class, $this->methodReflection->getDeclaringClassName());
-//    }
+    public function testInstance(): void
+    {
+        $this->assertInstanceOf(ClassMethodReflectionInterface::class, $this->methodReflection);
+    }
 
-//    public function testModificators(): void
-//    {
-//        $this->assertFalse($this->methodReflection->isAbstract());
-//        $this->assertFalse($this->methodReflection->isFinal());
-//        $this->assertFalse($this->methodReflection->isPrivate());
-//        $this->assertFalse($this->methodReflection->isProtected());
-//        $this->assertTrue($this->methodReflection->isPublic());
-//        $this->assertFalse($this->methodReflection->isStatic());
-//    }
-//
-//    public function testGetParameters(): void
-//    {
-//        $parameters = $this->methodReflection->getParameters();
-//        $this->assertCount(3, $parameters);
-//        $this->assertInstanceOf(MethodParameterReflectionInterface::class, $parameters['url']);
-//        $this->assertSame(['url', 'data', 'headers'], array_keys($parameters));
-//    }
+    public function testGetDeclaringClass(): void
+    {
+        $this->assertInstanceOf(ClassReflectionInterface::class, $this->methodReflection->getDeclaringClass());
+        $this->assertSame(ClassMethod::class, $this->methodReflection->getDeclaringClassName());
+    }
 
-//    public function testReturnReference(): void
-//    {
-//        $this->assertFalse($this->methodReflection->returnsReference());
-//    }
+    public function testModificators(): void
+    {
+        $this->assertFalse($this->methodReflection->isAbstract());
+        $this->assertFalse($this->methodReflection->isFinal());
+        $this->assertFalse($this->methodReflection->isPrivate());
+        $this->assertFalse($this->methodReflection->isProtected());
+        $this->assertTrue($this->methodReflection->isPublic());
+        $this->assertFalse($this->methodReflection->isStatic());
+    }
+
+    public function testGetParameters(): void
+    {
+        $parameters = $this->methodReflection->getParameters();
+        $this->assertCount(3, $parameters);
+        $this->assertInstanceOf(MethodParameterReflectionInterface::class, $parameters['url']);
+        $this->assertSame(['url', 'data', 'headers'], array_keys($parameters));
+    }
+
+    public function testReturnReference(): void
+    {
+        $this->assertFalse($this->methodReflection->returnsReference());
+    }
 }

--- a/packages/Reflection/tests/Reflection/Class_/ClassMethodReflection/ClassMethodReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassMethodReflection/ClassMethodReflectionTest.php
@@ -29,37 +29,37 @@ final class ClassMethodReflectionTest extends AbstractParserAwareTestCase
         $this->assertSame('methodWithArgs', $this->methodReflection->getName());
     }
 
-    public function testInstance(): void
-    {
-        $this->assertInstanceOf(ClassMethodReflectionInterface::class, $this->methodReflection);
-    }
+//    public function testInstance(): void
+//    {
+//        $this->assertInstanceOf(ClassMethodReflectionInterface::class, $this->methodReflection);
+//    }
+//
+//    public function testGetDeclaringClass(): void
+//    {
+//        $this->assertInstanceOf(ClassReflectionInterface::class, $this->methodReflection->getDeclaringClass());
+//        $this->assertSame(ClassMethod::class, $this->methodReflection->getDeclaringClassName());
+//    }
 
-    public function testGetDeclaringClass(): void
-    {
-        $this->assertInstanceOf(ClassReflectionInterface::class, $this->methodReflection->getDeclaringClass());
-        $this->assertSame(ClassMethod::class, $this->methodReflection->getDeclaringClassName());
-    }
+//    public function testModificators(): void
+//    {
+//        $this->assertFalse($this->methodReflection->isAbstract());
+//        $this->assertFalse($this->methodReflection->isFinal());
+//        $this->assertFalse($this->methodReflection->isPrivate());
+//        $this->assertFalse($this->methodReflection->isProtected());
+//        $this->assertTrue($this->methodReflection->isPublic());
+//        $this->assertFalse($this->methodReflection->isStatic());
+//    }
+//
+//    public function testGetParameters(): void
+//    {
+//        $parameters = $this->methodReflection->getParameters();
+//        $this->assertCount(3, $parameters);
+//        $this->assertInstanceOf(MethodParameterReflectionInterface::class, $parameters['url']);
+//        $this->assertSame(['url', 'data', 'headers'], array_keys($parameters));
+//    }
 
-    public function testModificators(): void
-    {
-        $this->assertFalse($this->methodReflection->isAbstract());
-        $this->assertFalse($this->methodReflection->isFinal());
-        $this->assertFalse($this->methodReflection->isPrivate());
-        $this->assertFalse($this->methodReflection->isProtected());
-        $this->assertTrue($this->methodReflection->isPublic());
-        $this->assertFalse($this->methodReflection->isStatic());
-    }
-
-    public function testGetParameters(): void
-    {
-        $parameters = $this->methodReflection->getParameters();
-        $this->assertCount(3, $parameters);
-        $this->assertInstanceOf(MethodParameterReflectionInterface::class, $parameters['url']);
-        $this->assertSame(['url', 'data', 'headers'], array_keys($parameters));
-    }
-
-    public function testReturnReference(): void
-    {
-        $this->assertFalse($this->methodReflection->returnsReference());
-    }
+//    public function testReturnReference(): void
+//    {
+//        $this->assertFalse($this->methodReflection->returnsReference());
+//    }
 }

--- a/packages/Reflection/tests/Reflection/Partial/AnnotationTest.php
+++ b/packages/Reflection/tests/Reflection/Partial/AnnotationTest.php
@@ -3,11 +3,11 @@
 namespace ApiGen\Reflection\Tests\Reflection\Partial;
 
 use ApiGen\Reflection\Contract\Reflection\Partial\AnnotationsInterface;
+use ApiGen\Reflection\DocBlock\Tags\See;
 use ApiGen\Reflection\Tests\Reflection\Partial\Source\SomeClassWithAnnotations;
 use ApiGen\Tests\AbstractParserAwareTestCase;
 use phpDocumentor\Reflection\DocBlock\Tags\Author;
 use phpDocumentor\Reflection\DocBlock\Tags\Generic;
-use phpDocumentor\Reflection\DocBlock\Tags\See;
 
 final class AnnotationTest extends AbstractParserAwareTestCase
 {

--- a/src/config/services.yml
+++ b/src/config/services.yml
@@ -29,6 +29,7 @@ services:
     phpDocumentor\Reflection\FqsenResolver: ~
     phpDocumentor\Reflection\DocBlock\StandardTagFactory: ~
     phpDocumentor\Reflection\DocBlock\DescriptionFactory: ~
+    phpDocumentor\Reflection\TypeResolver: ~
 
     # Source Code Highlighter
     FSHL\Output\Html: ~

--- a/src/config/services.yml
+++ b/src/config/services.yml
@@ -15,7 +15,7 @@ services:
         exclude: '../../packages/ModularConfiguration/src/{Exception}'
     ApiGen\Reflection\:
         resource: '../../packages/Reflection/src'
-        exclude: '../../packages/Reflection/src/{Exception,Reflection}'
+        exclude: '../../packages/Reflection/src/{Exception,Reflection,DocBlock/Tags}'
     ApiGen\StringRouting\:
         resource: '../../packages/StringRouting/src'
 
@@ -24,10 +24,11 @@ services:
         factory: 'ApiGen\Latte\FiltersAwareLatteEngineFactory:create'
 
     # PHP Documentor
-    phpDocumentor\Reflection\DocBlockFactory:
-        factory: phpDocumentor\Reflection\DocBlockFactory::createInstance
+    phpDocumentor\Reflection\DocBlockFactory: ~
     phpDocumentor\Reflection\Types\ContextFactory: ~
     phpDocumentor\Reflection\FqsenResolver: ~
+    phpDocumentor\Reflection\DocBlock\StandardTagFactory: ~
+    phpDocumentor\Reflection\DocBlock\DescriptionFactory: ~
 
     # Source Code Highlighter
     FSHL\Output\Html: ~


### PR DESCRIPTION
This should solve #936 and #864 


### Use Case Code

```php
/**
 * @link http://php.net/session_set_save_handler
 * @see https://github.com/apigen/apigen
 */
final class ClassWithLinkAndSeeAnnotations
{
}
```

### Before 

```bash
 ~/projects/ApiGen [master]  % ./bin/apigen generate --destination=api
                                                                           
  [InvalidArgumentException]                                               
  "\https://github.com/apigen/apigen" is not a valid Fqsen.  
```

### After

Generation was successful:

```html
<a href="http://php.net/session_set_save_handler">http://php.net/session_set_save_handler</a>
<a href="https://github.com/apigen/apigen">https://github.com/apigen/apigen</a>
```