### PR TITLE
RelativePathResolver: fix for functions loaded from file source

### DIFF
--- a/src/Utils/RelativePathResolver.php
+++ b/src/Utils/RelativePathResolver.php
@@ -44,6 +44,10 @@ final class RelativePathResolver
         $directory = $this->fileSystem->normalizePath($directory);
         $fileName = $this->fileSystem->normalizePath($fileName);
 
+        if (is_file($directory)) {
+            $directory = dirname($directory);
+        }
+
         return substr($fileName, strlen($directory) + 1);
     }
 }


### PR DESCRIPTION
When second parameter of `substr` is bigger than actual size of the string, it returns `FALSE` and it fails on type hint restriction where just a string is expected.