### PR TITLE
Reflection: allowed nullable filenames

### DIFF
--- a/packages/Reflection/src/Contract/Reflection/Class_/ClassReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Class_/ClassReflectionInterface.php
@@ -3,6 +3,7 @@
 namespace ApiGen\Reflection\Contract\Reflection\Class_;
 
 use ApiGen\Reflection\Contract\Reflection\AbstractReflectionInterface;
+use ApiGen\Reflection\Contract\Reflection\FileNameAwareReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\AnnotationsInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\InNamespaceInterface;
@@ -11,13 +12,11 @@ use ApiGen\Reflection\Contract\Reflection\Trait_\TraitMethodReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Trait_\TraitReflectionInterface;
 
 interface ClassReflectionInterface extends StartAndEndLineInterface, AnnotationsInterface, AbstractReflectionInterface,
-    InNamespaceInterface
+    InNamespaceInterface, FileNameAwareReflectionInterface
 {
     public function getParentClass(): ?ClassReflectionInterface;
 
     public function getParentClassName(): ?string;
-
-    public function getFileName(): ?string;
 
     /**
      * @return ClassReflectionInterface[]

--- a/packages/Reflection/src/Contract/Reflection/Class_/ClassReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Class_/ClassReflectionInterface.php
@@ -17,7 +17,7 @@ interface ClassReflectionInterface extends StartAndEndLineInterface, Annotations
 
     public function getParentClassName(): ?string;
 
-    public function getFileName(): string;
+    public function getFileName(): ?string;
 
     /**
      * @return ClassReflectionInterface[]

--- a/packages/Reflection/src/Contract/Reflection/FileNameAwareReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/FileNameAwareReflectionInterface.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Reflection\Contract\Reflection;
+
+interface FileNameAwareReflectionInterface
+{
+    public function getFileName(): ?string;
+}

--- a/packages/Reflection/src/Contract/Reflection/FileNameAwareReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/FileNameAwareReflectionInterface.php
@@ -4,5 +4,8 @@ namespace ApiGen\Reflection\Contract\Reflection;
 
 interface FileNameAwareReflectionInterface
 {
+    /**
+     * @return string|null  returns null for PHP internal classes
+     */
     public function getFileName(): ?string;
 }

--- a/packages/Reflection/src/Contract/Reflection/Function_/FunctionReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Function_/FunctionReflectionInterface.php
@@ -19,5 +19,5 @@ interface FunctionReflectionInterface extends StartAndEndLineInterface, Annotati
 
     public function getShortName(): string;
 
-    public function getFileName(): string;
+    public function getFileName(): ?string;
 }

--- a/packages/Reflection/src/Contract/Reflection/Function_/FunctionReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Function_/FunctionReflectionInterface.php
@@ -3,12 +3,13 @@
 namespace ApiGen\Reflection\Contract\Reflection\Function_;
 
 use ApiGen\Reflection\Contract\Reflection\AbstractReflectionInterface;
+use ApiGen\Reflection\Contract\Reflection\FileNameAwareReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\AnnotationsInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\InNamespaceInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\StartAndEndLineInterface;
 
 interface FunctionReflectionInterface extends StartAndEndLineInterface, AnnotationsInterface,
-    AbstractReflectionInterface, InNamespaceInterface
+    AbstractReflectionInterface, InNamespaceInterface, FileNameAwareReflectionInterface
 {
     public function returnsReference(): bool;
 
@@ -18,6 +19,4 @@ interface FunctionReflectionInterface extends StartAndEndLineInterface, Annotati
     public function getParameters(): array;
 
     public function getShortName(): string;
-
-    public function getFileName(): ?string;
 }

--- a/packages/Reflection/src/Contract/Reflection/Interface_/InterfaceReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Interface_/InterfaceReflectionInterface.php
@@ -4,15 +4,14 @@ namespace ApiGen\Reflection\Contract\Reflection\Interface_;
 
 use ApiGen\Reflection\Contract\Reflection\AbstractReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
+use ApiGen\Reflection\Contract\Reflection\FileNameAwareReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\AnnotationsInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\InNamespaceInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\StartAndEndLineInterface;
 
 interface InterfaceReflectionInterface extends StartAndEndLineInterface, AnnotationsInterface,
-    AbstractReflectionInterface, InNamespaceInterface
+    AbstractReflectionInterface, InNamespaceInterface, FileNameAwareReflectionInterface
 {
-    public function getFileName(): ?string;
-
     /**
      * @return ClassReflectionInterface[]|InterfaceReflectionInterface[]
      */

--- a/packages/Reflection/src/Contract/Reflection/Interface_/InterfaceReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Interface_/InterfaceReflectionInterface.php
@@ -11,7 +11,7 @@ use ApiGen\Reflection\Contract\Reflection\Partial\StartAndEndLineInterface;
 interface InterfaceReflectionInterface extends StartAndEndLineInterface, AnnotationsInterface,
     AbstractReflectionInterface, InNamespaceInterface
 {
-    public function getFileName(): string;
+    public function getFileName(): ?string;
 
     /**
      * @return ClassReflectionInterface[]|InterfaceReflectionInterface[]

--- a/packages/Reflection/src/Contract/Reflection/Trait_/TraitReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Trait_/TraitReflectionInterface.php
@@ -13,7 +13,7 @@ interface TraitReflectionInterface extends AnnotationsInterface, AbstractReflect
 
     public function isDeprecated(): bool;
 
-    public function getFileName(): string;
+    public function getFileName(): ?string;
 
     /**
      * @return ClassReflectionInterface[]|TraitReflectionInterface[]

--- a/packages/Reflection/src/Contract/Reflection/Trait_/TraitReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Trait_/TraitReflectionInterface.php
@@ -4,16 +4,16 @@ namespace ApiGen\Reflection\Contract\Reflection\Trait_;
 
 use ApiGen\Reflection\Contract\Reflection\AbstractReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
+use ApiGen\Reflection\Contract\Reflection\FileNameAwareReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\AnnotationsInterface;
 use ApiGen\Reflection\Contract\Reflection\Partial\InNamespaceInterface;
 
-interface TraitReflectionInterface extends AnnotationsInterface, AbstractReflectionInterface, InNamespaceInterface
+interface TraitReflectionInterface extends AnnotationsInterface, AbstractReflectionInterface, InNamespaceInterface,
+    FileNameAwareReflectionInterface
 {
     public function getShortName(): string;
 
     public function isDeprecated(): bool;
-
-    public function getFileName(): ?string;
 
     /**
      * @return ClassReflectionInterface[]|TraitReflectionInterface[]

--- a/packages/Reflection/src/Reflection/Class_/ClassReflection.php
+++ b/packages/Reflection/src/Reflection/Class_/ClassReflection.php
@@ -370,7 +370,7 @@ final class ClassReflection implements ClassReflectionInterface, TransformerColl
         return $this->docBlock->hasTag($name);
     }
 
-    public function getFileName(): string
+    public function getFileName(): ?string
     {
         return $this->betterClassReflection->getFileName();
     }

--- a/packages/Reflection/src/Reflection/Function_/FunctionReflection.php
+++ b/packages/Reflection/src/Reflection/Function_/FunctionReflection.php
@@ -108,7 +108,7 @@ final class FunctionReflection implements FunctionReflectionInterface, Transform
         );
     }
 
-    public function getFileName(): string
+    public function getFileName(): ?string
     {
         return $this->betterFunctionReflection->getFileName();
     }

--- a/packages/Reflection/src/Reflection/Interface_/InterfaceReflection.php
+++ b/packages/Reflection/src/Reflection/Interface_/InterfaceReflection.php
@@ -88,7 +88,7 @@ final class InterfaceReflection implements InterfaceReflectionInterface, Transfo
         return $this->implementersResolver->getImplementers($this);
     }
 
-    public function getFileName(): string
+    public function getFileName(): ?string
     {
         return $this->betterInterfaceReflection->getFileName();
     }

--- a/packages/Reflection/src/Reflection/Trait_/TraitReflection.php
+++ b/packages/Reflection/src/Reflection/Trait_/TraitReflection.php
@@ -91,7 +91,7 @@ final class TraitReflection implements TraitReflectionInterface, TransformerColl
         return $this->betterTraitReflection->getNamespaceName();
     }
 
-    public function getFileName(): string
+    public function getFileName(): ?string
     {
         return $this->betterTraitReflection->getFileName();
     }

--- a/packages/Reflection/tests/Reflection/Class_/ClassReflection/ClassReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassReflection/ClassReflectionTest.php
@@ -5,8 +5,10 @@ namespace ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
 use ApiGen\Reflection\Parser\Parser;
 use ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection\Source\SomeClass;
+use ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection\Source\SuccessorOfInternalClass;
 use ApiGen\Tests\AbstractParserAwareTestCase;
 use phpDocumentor\Reflection\DocBlock\Tags\Author;
+use Directory;
 
 final class ClassReflectionTest extends AbstractParserAwareTestCase
 {
@@ -20,6 +22,11 @@ final class ClassReflectionTest extends AbstractParserAwareTestCase
      */
     private $classReflection;
 
+    /**
+     * @var ClassReflectionInterface
+     */
+    private $internalClassSuccessorClassReflection;
+
     protected function setUp(): void
     {
         /** @var Parser $parser */
@@ -27,6 +34,7 @@ final class ClassReflectionTest extends AbstractParserAwareTestCase
 
         $classReflections = $this->reflectionStorage->getClassReflections();
         $this->classReflection = $classReflections[SomeClass::class];
+        $this->internalClassSuccessorClassReflection = $classReflections[SuccessorOfInternalClass::class];
     }
 
     public function testInterface(): void
@@ -71,5 +79,8 @@ final class ClassReflectionTest extends AbstractParserAwareTestCase
     public function testFileName(): void
     {
         $this->assertSame(__DIR__ . '/Source/SomeClass.php', $this->classReflection->getFileName());
+
+        $parents = $this->internalClassSuccessorClassReflection->getParentClasses();
+        $this->assertNull($parents[Directory::class]->getFileName());
     }
 }

--- a/packages/Reflection/tests/Reflection/Class_/ClassReflection/ClassReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassReflection/ClassReflectionTest.php
@@ -67,4 +67,9 @@ final class ClassReflectionTest extends AbstractParserAwareTestCase
         $this->assertFalse($this->classReflection->isAbstract());
         $this->assertFalse($this->classReflection->isFinal());
     }
+
+    public function testFileName(): void
+    {
+        $this->assertSame(__DIR__ . '/Source/SomeClass.php', $this->classReflection->getFileName());
+    }
 }

--- a/packages/Reflection/tests/Reflection/Class_/ClassReflection/ClassReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassReflection/ClassReflectionTest.php
@@ -7,8 +7,8 @@ use ApiGen\Reflection\Parser\Parser;
 use ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection\Source\SomeClass;
 use ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection\Source\SuccessorOfInternalClass;
 use ApiGen\Tests\AbstractParserAwareTestCase;
-use phpDocumentor\Reflection\DocBlock\Tags\Author;
 use Directory;
+use phpDocumentor\Reflection\DocBlock\Tags\Author;
 
 final class ClassReflectionTest extends AbstractParserAwareTestCase
 {

--- a/packages/Reflection/tests/Reflection/Class_/ClassReflection/Source/SuccessorOfInternalClass.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassReflection/Source/SuccessorOfInternalClass.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection\Source;
+
+use Directory;
+
+class SuccessorOfInternalClass extends Directory
+{
+}

--- a/packages/Reflection/tests/Reflection/Function_/FunctionReflection/FunctionReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Function_/FunctionReflection/FunctionReflectionTest.php
@@ -84,4 +84,9 @@ final class FunctionReflectionTest extends AbstractParserAwareTestCase
 
         $this->assertSame(['number', 'name', 'arguments'], array_keys($parameters));
     }
+
+    public function testFileName(): void
+    {
+        $this->assertSame(__DIR__ . '/Source/SomeFunction.php', $this->functionReflection->getFileName());
+    }
 }

--- a/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/InterfaceReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/InterfaceReflectionTest.php
@@ -2,6 +2,7 @@
 
 namespace ApiGen\Reflection\Tests\Reflection\Interface_\InterfaceReflection;
 
+use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterface;
 use ApiGen\Reflection\Tests\Reflection\Interface_\InterfaceReflection\Source\PoorInterface;
 use ApiGen\Reflection\Tests\Reflection\Interface_\InterfaceReflection\Source\RichInterface;

--- a/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/InterfaceReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/InterfaceReflectionTest.php
@@ -5,8 +5,10 @@ namespace ApiGen\Reflection\Tests\Reflection\Interface_\InterfaceReflection;
 use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterface;
 use ApiGen\Reflection\Tests\Reflection\Interface_\InterfaceReflection\Source\PoorInterface;
 use ApiGen\Reflection\Tests\Reflection\Interface_\InterfaceReflection\Source\RichInterface;
+use ApiGen\Reflection\Tests\Reflection\Interface_\InterfaceReflection\Source\SomeClass;
 use ApiGen\Reflection\Tests\Reflection\Interface_\InterfaceReflection\Source\SomeInterface;
 use ApiGen\Tests\AbstractParserAwareTestCase;
+use Countable;
 
 final class InterfaceReflectionTest extends AbstractParserAwareTestCase
 {
@@ -15,12 +17,20 @@ final class InterfaceReflectionTest extends AbstractParserAwareTestCase
      */
     private $interfaceReflection;
 
+    /**
+     * @var ClassReflectionInterface
+     */
+    private $classReflection;
+
     protected function setUp(): void
     {
         $this->parser->parseFilesAndDirectories([__DIR__ . '/Source']);
 
         $interfaceReflections = $this->reflectionStorage->getInterfaceReflections();
         $this->interfaceReflection = $interfaceReflections[SomeInterface::class];
+
+        $classReflections = $this->reflectionStorage->getClassReflections();
+        $this->classReflection = $classReflections[SomeClass::class];
     }
 
     public function testNames(): void
@@ -54,5 +64,8 @@ final class InterfaceReflectionTest extends AbstractParserAwareTestCase
     public function testFileName(): void
     {
         $this->assertSame(__DIR__ . '/Source/SomeInterface.php', $this->interfaceReflection->getFileName());
+
+        $interfaces = $this->classReflection->getInterfaces();
+        $this->assertNull($interfaces[Countable::class]->getFileName());
     }
 }

--- a/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/InterfaceReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/InterfaceReflectionTest.php
@@ -50,4 +50,9 @@ final class InterfaceReflectionTest extends AbstractParserAwareTestCase
         $this->assertSame(5, $this->interfaceReflection->getStartLine());
         $this->assertSame(8, $this->interfaceReflection->getEndLine());
     }
+
+    public function testFileName(): void
+    {
+        $this->assertSame(__DIR__ . '/Source/SomeInterface.php', $this->interfaceReflection->getFileName());
+    }
 }

--- a/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/Source/SomeClass.php
+++ b/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/Source/SomeClass.php
@@ -2,7 +2,9 @@
 
 namespace ApiGen\Reflection\Tests\Reflection\Interface_\InterfaceReflection\Source;
 
-final class SomeClass implements SomeInterface
+use Countable;
+
+final class SomeClass implements SomeInterface, Countable
 {
     public function getSomeStuff(): void
     {
@@ -10,5 +12,10 @@ final class SomeClass implements SomeInterface
 
     public function riseAndShine(): void
     {
+    }
+
+    public function count(): int
+    {
+        return 11;
     }
 }

--- a/packages/Reflection/tests/Reflection/Trait_/TraitReflection/TraitReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Trait_/TraitReflection/TraitReflectionTest.php
@@ -45,4 +45,9 @@ final class TraitReflectionTest extends AbstractParserAwareTestCase
             'renamedMethod' => ToBeAliasedTrait::class . '::aliasedParentMethod',
         ], $this->traitReflection->getTraitAliases());
     }
+
+    public function testFileName(): void
+    {
+        $this->assertSame(__DIR__ . '/Source/SimpleTrait.php', $this->traitReflection->getFileName());
+    }
 }

--- a/src/Console/Progress/StepCounter.php
+++ b/src/Console/Progress/StepCounter.php
@@ -4,7 +4,7 @@ namespace ApiGen\Console\Progress;
 
 use ApiGen\Element\Namespace_\ParentEmptyNamespacesResolver;
 use ApiGen\Element\ReflectionCollector\NamespaceReflectionCollector;
-use ApiGen\Reflection\Contract\Reflection\AbstractReflectionInterface;
+use ApiGen\Reflection\Contract\Reflection\FileNameAwareReflectionInterface;
 use ApiGen\Reflection\ReflectionStorage;
 
 final class StepCounter
@@ -51,8 +51,17 @@ final class StepCounter
             + $this->getOverviewPagesCount();
     }
 
+    private function getSourceCodeStepCount(): int
+    {
+        return $this->getSourceCodeCountForReflections($this->reflectionStorage->getClassReflections())
+            + $this->getSourceCodeCountForReflections($this->reflectionStorage->getExceptionReflections())
+            + $this->getSourceCodeCountForReflections($this->reflectionStorage->getInterfaceReflections())
+            + $this->getSourceCodeCountForReflections($this->reflectionStorage->getTraitReflections())
+            + $this->getSourceCodeCountForReflections($this->reflectionStorage->getFunctionReflections());
+    }
+
     /**
-     * @param AbstractReflectionInterface[]
+     * @param FileNameAwareReflectionInterface[]
      */
     private function getSourceCodeCountForReflections(array $reflections): int
     {
@@ -64,15 +73,6 @@ final class StepCounter
         }
 
         return $count;
-    }
-
-    private function getSourceCodeStepCount(): int
-    {
-        return $this->getSourceCodeCountForReflections($this->reflectionStorage->getClassReflections())
-            + $this->getSourceCodeCountForReflections($this->reflectionStorage->getExceptionReflections())
-            + $this->getSourceCodeCountForReflections($this->reflectionStorage->getInterfaceReflections())
-            + $this->getSourceCodeCountForReflections($this->reflectionStorage->getTraitReflections())
-            + $this->getSourceCodeCountForReflections($this->reflectionStorage->getFunctionReflections());
     }
 
     private function getOverviewPagesCount(): int

--- a/src/Console/Progress/StepCounter.php
+++ b/src/Console/Progress/StepCounter.php
@@ -4,6 +4,7 @@ namespace ApiGen\Console\Progress;
 
 use ApiGen\Element\Namespace_\ParentEmptyNamespacesResolver;
 use ApiGen\Element\ReflectionCollector\NamespaceReflectionCollector;
+use ApiGen\Reflection\Contract\Reflection\AbstractReflectionInterface;
 use ApiGen\Reflection\ReflectionStorage;
 
 final class StepCounter
@@ -50,40 +51,28 @@ final class StepCounter
             + $this->getOverviewPagesCount();
     }
 
-    private function getSourceCodeStepCount(): int
+    /**
+     * @param AbstractReflectionInterface[]
+     */
+    private function getSourceCodeCountForReflections(array $reflections): int
     {
         $count = 0;
-        foreach ($this->reflectionStorage->getClassReflections() as $classReflection) {
-            if ($classReflection->getFileName()) {
-                $count++;
-            }
-        }
-
-        foreach ($this->reflectionStorage->getExceptionReflections() as $exceptionReflection) {
-            if ($exceptionReflection->getFileName()) {
-                $count++;
-            }
-        }
-
-        foreach ($this->reflectionStorage->getInterfaceReflections() as $interfaceReflection) {
-            if ($interfaceReflection->getFileName()) {
-                $count++;
-            }
-        }
-
-        foreach ($this->reflectionStorage->getTraitReflections() as $traitReflection) {
-            if ($traitReflection->getFileName()) {
-                $count++;
-            }
-        }
-
-        foreach ($this->reflectionStorage->getFunctionReflections() as $functionReflection) {
-            if ($functionReflection->getFileName()) {
+        foreach ($reflections as $reflection) {
+            if ($reflection->getFileName()) {
                 $count++;
             }
         }
 
         return $count;
+    }
+
+    private function getSourceCodeStepCount(): int
+    {
+        return $this->getSourceCodeCountForReflections($this->reflectionStorage->getClassReflections())
+            + $this->getSourceCodeCountForReflections($this->reflectionStorage->getExceptionReflections())
+            + $this->getSourceCodeCountForReflections($this->reflectionStorage->getInterfaceReflections())
+            + $this->getSourceCodeCountForReflections($this->reflectionStorage->getTraitReflections())
+            + $this->getSourceCodeCountForReflections($this->reflectionStorage->getFunctionReflections());
     }
 
     private function getOverviewPagesCount(): int

--- a/src/Console/Progress/StepCounter.php
+++ b/src/Console/Progress/StepCounter.php
@@ -52,11 +52,38 @@ final class StepCounter
 
     private function getSourceCodeStepCount(): int
     {
-        return count($this->reflectionStorage->getClassReflections())
-            + count($this->reflectionStorage->getExceptionReflections())
-            + count($this->reflectionStorage->getInterfaceReflections())
-            + count($this->reflectionStorage->getTraitReflections())
-            + count($this->reflectionStorage->getFunctionReflections());
+        $count = 0;
+        foreach ($this->reflectionStorage->getClassReflections() as $classReflection) {
+            if ($classReflection->getFileName()) {
+                $count++;
+            }
+        }
+
+        foreach ($this->reflectionStorage->getExceptionReflections() as $exceptionReflection) {
+            if ($exceptionReflection->getFileName()) {
+                $count++;
+            }
+        }
+
+        foreach ($this->reflectionStorage->getInterfaceReflections() as $interfaceReflection) {
+            if ($interfaceReflection->getFileName()) {
+                $count++;
+            }
+        }
+
+        foreach ($this->reflectionStorage->getTraitReflections() as $traitReflection) {
+            if ($traitReflection->getFileName()) {
+                $count++;
+            }
+        }
+
+        foreach ($this->reflectionStorage->getFunctionReflections() as $functionReflection) {
+            if ($functionReflection->getFileName()) {
+                $count++;
+            }
+        }
+
+        return $count;
     }
 
     private function getOverviewPagesCount(): int

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -47,7 +47,9 @@ final class ClassGenerator implements GeneratorInterface
     {
         foreach ($this->reflectionStorage->getClassReflections() as $classReflection) {
             $this->generateForClass($classReflection);
-            $this->generateSourceCodeForClass($classReflection);
+            if ($classReflection->getFileName()) {
+                $this->generateSourceCodeForClass($classReflection);
+            }
         }
     }
 

--- a/src/Generator/ExceptionGenerator.php
+++ b/src/Generator/ExceptionGenerator.php
@@ -47,7 +47,9 @@ final class ExceptionGenerator implements GeneratorInterface
     {
         foreach ($this->reflectionStorage->getExceptionReflections() as $exceptionReflection) {
             $this->generateForException($exceptionReflection);
-            $this->generateSourceCodeForException($exceptionReflection);
+            if ($exceptionReflection->getFileName()) {
+                $this->generateSourceCodeForException($exceptionReflection);
+            }
         }
     }
 

--- a/src/Generator/FunctionGenerator.php
+++ b/src/Generator/FunctionGenerator.php
@@ -53,9 +53,11 @@ final class FunctionGenerator implements GeneratorInterface
 
     public function generate(): void
     {
-        foreach ($this->reflectionStorage->getFunctionReflections() as $reflectionFunction) {
-            $this->generateForFunction($reflectionFunction);
-            $this->generateSourceCodeForFunction($reflectionFunction);
+        foreach ($this->reflectionStorage->getFunctionReflections() as $functionReflection) {
+            $this->generateForFunction($functionReflection);
+            if ($functionReflection->getFileName()) {
+                $this->generateSourceCodeForFunction($functionReflection);
+            }
         }
     }
 

--- a/src/Generator/InterfaceGenerator.php
+++ b/src/Generator/InterfaceGenerator.php
@@ -47,7 +47,9 @@ final class InterfaceGenerator implements GeneratorInterface
     {
         foreach ($this->reflectionStorage->getInterfaceReflections() as $interfaceReflection) {
             $this->generateForInterface($interfaceReflection);
-            $this->generateSourceCodeForInterface($interfaceReflection);
+            if ($interfaceReflection->getFileName()) {
+                $this->generateSourceCodeForInterface($interfaceReflection);
+            }
         }
     }
 

--- a/src/Generator/TraitGenerator.php
+++ b/src/Generator/TraitGenerator.php
@@ -47,7 +47,9 @@ final class TraitGenerator implements GeneratorInterface
     {
         foreach ($this->reflectionStorage->getTraitReflections() as $traitReflection) {
             $this->generateForTrait($traitReflection);
-            $this->generateSourceCodeForTrait($traitReflection);
+            if ($traitReflection->getFileName()) {
+                $this->generateSourceCodeForTrait($traitReflection);
+            }
         }
     }
 


### PR DESCRIPTION
Output of `BetterReflection*::getFileName()` is nullable for internal PHP classes do not have source. We do not support generating API for PHP's internal classes but we need to. After it, current version would fail on type hint check.