### PR TITLE
Parser: fixed file source loader

### DIFF
--- a/packages/Reflection/src/Parser/Parser.php
+++ b/packages/Reflection/src/Parser/Parser.php
@@ -172,7 +172,11 @@ final class Parser
      */
     private function createFilesSource(array $files): SourceLocator
     {
-        $locators = [];
+        $locators = [
+            new AutoloadSourceLocator(),
+            new PhpInternalSourceLocator()
+        ];
+
         foreach ($files as $file) {
             $locators[] = new SingleFileSourceLocator($file);
         }

--- a/packages/Reflection/tests/Parser/NotLoadedSources/SomeCountableClass.php
+++ b/packages/Reflection/tests/Parser/NotLoadedSources/SomeCountableClass.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Reflection\Tests\Parser\NotLoadedSources;
+
+use Countable;
+
+final class SomeCountableClass implements Countable
+{
+    public function count(): int
+    {
+        return 11;
+    }
+}

--- a/packages/Reflection/tests/Parser/ParserTest.php
+++ b/packages/Reflection/tests/Parser/ParserTest.php
@@ -6,6 +6,7 @@ use ApiGen\Reflection\Parser\Parser;
 use ApiGen\Reflection\ReflectionStorage;
 use ApiGen\Reflection\Tests\Parser\AnotherSource\ParentClassFromAnotherSource;
 use ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeClass;
+use ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeCountableClass;
 use ApiGen\Tests\AbstractContainerAwareTestCase;
 
 final class ParserTest extends AbstractContainerAwareTestCase
@@ -23,5 +24,18 @@ final class ParserTest extends AbstractContainerAwareTestCase
         $classReflections = $reflectionStorage->getClassReflections();
         $this->assertArrayHasKey(SomeClass::class, $classReflections);
         $this->assertArrayHasKey(ParentClassFromAnotherSource::class, $classReflections);
+    }
+
+    public function testFiles(): void
+    {
+        $parser = $this->container->get(Parser::class);
+        $reflectionStorage = $this->container->get(ReflectionStorage::class);
+
+        $parser->parseFilesAndDirectories([
+            __DIR__ . '/NotLoadedSources/SomeCountableClass.php',
+        ]);
+
+        $classReflections = $reflectionStorage->getClassReflections();
+        $this->assertArrayHasKey(SomeCountableClass::class, $classReflections);
     }
 }


### PR DESCRIPTION
When loading only from file (without directories), autoloaded classes or PHP's internal interfaces were ignored.

Without the fix, test has been throwing this:

```
Roave\BetterReflection\Reflector\Exception\IdentifierNotFound:
Roave\BetterReflection\Reflection\ReflectionClass "Countable" could not be found in the located source
```