### PR TITLE
added support for interface constants [WIP]

### DIFF
--- a/packages/Reflection/src/Reflection/Class_/ClassConstantReflection.php
+++ b/packages/Reflection/src/Reflection/Class_/ClassConstantReflection.php
@@ -84,6 +84,11 @@ final class ClassConstantReflection implements ClassConstantReflectionInterface,
         return $this->constant->getValue();
     }
 
+    public function getValueDefinition(): string
+    {
+        return 'TODO'; // $this->constant->getValueAsString(); FIXME
+    }
+
     public function isDeprecated(): bool
     {
         if ($this->getDeclaringClass()->isDeprecated()) {

--- a/packages/Reflection/src/Reflection/Interface_/InterfaceConstantReflection.php
+++ b/packages/Reflection/src/Reflection/Interface_/InterfaceConstantReflection.php
@@ -2,76 +2,64 @@
 
 namespace ApiGen\Reflection\Reflection\Interface_;
 
+use ApiGen\Annotation\AnnotationList;
 use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceConstantReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterface;
+use ApiGen\Reflection\Contract\TransformerCollectorAwareInterface;
+use ApiGen\Reflection\TransformerCollector;
+use phpDocumentor\Reflection\DocBlock;
+use Roave\BetterReflection\Reflection\ReflectionClassConstant;
 
 /**
  * @inspiration https://github.com/POPSuL/PHP-Token-Reflection/blob/develop/TokenReflection/Php/ReflectionConstant.php
  */
-final class InterfaceConstantReflection implements InterfaceConstantReflectionInterface
+final class InterfaceConstantReflection implements InterfaceConstantReflectionInterface,
+    TransformerCollectorAwareInterface
 {
     /**
-     * @var string
+     * @var ReflectionClassConstant
      */
-    private $name;
+    private $betterConstantReflection;
 
     /**
-     * @var mixed
+     * @var DocBlock
      */
-    private $value;
+    private $docBlock;
 
     /**
-     * @var InterfaceReflectionInterface
+     * @var TransformerCollector
      */
-    private $interfaceReflection;
+    private $transformerCollector;
 
-    /**
-     * @param mixed $value
-     */
-    private function __construct(string $name, $value, InterfaceReflectionInterface $interfaceReflection)
+    public function __construct(ReflectionClassConstant $constant, DocBlock $docBlock)
     {
-        $this->name = $name;
-        $this->value = $value;
-        $this->interfaceReflection = $interfaceReflection;
-    }
-
-    /**
-     * @param mixed $value
-     */
-    public static function createFromNameValueAndInterface(
-        string $name,
-        $value,
-        InterfaceReflectionInterface $interfaceReflection
-    ): self {
-        return new self($name, $value, $interfaceReflection);
+        $this->betterConstantReflection = $constant;
+        $this->docBlock = $docBlock;
     }
 
     public function isPrivate(): bool
     {
-        // @todo
-        return false;
+        return $this->betterConstantReflection->isPrivate();
     }
 
     public function isProtected(): bool
     {
-        // @todo
-        return false;
+        return $this->betterConstantReflection->isProtected();
     }
 
     public function isPublic(): bool
     {
-        // @todo
-        return false;
+        return $this->betterConstantReflection->isPublic();
     }
 
     public function getName(): string
     {
-        return $this->name;
+        return $this->betterConstantReflection->getName();
     }
 
     public function getTypeHint(): string
     {
-        $valueType = gettype($this->value);
+        $valueType = gettype($this->betterConstantReflection->getValue());
         if ($valueType === 'integer') {
             return 'int';
         }
@@ -84,28 +72,69 @@ final class InterfaceConstantReflection implements InterfaceConstantReflectionIn
      */
     public function getValue()
     {
-        return $this->value;
+        return $this->betterConstantReflection->getValue();
+    }
+
+    public function getValueDefinition(): string
+    {
+        return 'TODO'; // $this->constant->getValueAsString(); FIXME
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getAnnotations(): array
+    {
+        return $this->docBlock->getTags();
+    }
+
+    public function hasAnnotation(string $name): bool
+    {
+        return $this->docBlock->hasTag($name);
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getAnnotation(string $name): array
+    {
+        return $this->docBlock->getTagsByName($name);
     }
 
     public function isDeprecated(): bool
     {
+        if ($this->getDeclaringInterface()->isDeprecated()) {
+            return true;
+        }
+
+        return $this->hasAnnotation(AnnotationList::DEPRECATED);
     }
 
     public function getStartLine(): int
     {
+        return $this->betterConstantReflection->getStartLine();
     }
 
     public function getEndLine(): int
     {
-    }
-
-    public function getDeclaringInterfaceName(): string
-    {
-        $this->interfaceReflection->getName();
+        return $this->betterConstantReflection->getEndLine();
     }
 
     public function getDeclaringInterface(): InterfaceReflectionInterface
     {
-        return $this->interfaceReflection;
+        return $this->transformerCollector->transformSingle(
+            $this->betterConstantReflection->getDeclaringClass()
+        );
+    }
+
+    public function getDeclaringInterfaceName(): string
+    {
+        return $this->getDeclaringInterface()
+            ->getName();
+    }
+
+    public function setTransformerCollector(TransformerCollector $transformerCollector): void
+    {
+        $this->transformerCollector = $transformerCollector;
     }
 }

--- a/packages/Reflection/src/Reflection/Interface_/InterfaceReflection.php
+++ b/packages/Reflection/src/Reflection/Interface_/InterfaceReflection.php
@@ -133,16 +133,9 @@ final class InterfaceReflection implements InterfaceReflectionInterface, Transfo
      */
     public function getOwnConstants(): array
     {
-        $ownConstants = [];
-        foreach ($this->betterInterfaceReflection->getConstants() as $name => $value) {
-            $ownConstants[] = InterfaceConstantReflection::createFromNameValueAndInterface(
-                $name,
-                $value,
-                $this
-            );
-        }
-
-        return $ownConstants;
+        return $this->transformerCollector->transformGroup(
+            $this->betterInterfaceReflection->getReflectionConstants()
+        );
     }
 
     /**

--- a/packages/Reflection/src/Transformer/BetterReflection/Interface_/InterfaceConstantReflectionTransformer.php
+++ b/packages/Reflection/src/Transformer/BetterReflection/Interface_/InterfaceConstantReflectionTransformer.php
@@ -1,14 +1,14 @@
 <?php declare(strict_types=1);
 
-namespace ApiGen\Reflection\Transformer\BetterReflection\Class_;
+namespace ApiGen\Reflection\Transformer\BetterReflection\Interface_;
 
-use ApiGen\Reflection\Contract\Reflection\Class_\ClassConstantReflectionInterface;
+use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceConstantReflectionInterface;
 use ApiGen\Reflection\Contract\Transformer\TransformerInterface;
-use ApiGen\Reflection\Reflection\Class_\ClassConstantReflection;
+use ApiGen\Reflection\Reflection\Interface_\InterfaceConstantReflection;
 use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use Roave\BetterReflection\Reflection\ReflectionClassConstant;
 
-final class ClassConstantReflectionTransformer implements TransformerInterface
+final class InterfaceConstantReflectionTransformer implements TransformerInterface
 {
     /**
      * @var DocBlockFactoryInterface
@@ -26,8 +26,7 @@ final class ClassConstantReflectionTransformer implements TransformerInterface
     public function matches($reflection): bool
     {
         if (! $reflection instanceof ReflectionClassConstant ||
-           ($reflection->getDeclaringClass()->isInterface() ||
-            $reflection->getDeclaringClass()->isTrait())
+            ! $reflection->getDeclaringClass()->isInterface()
         ) {
             return false;
         }
@@ -38,10 +37,10 @@ final class ClassConstantReflectionTransformer implements TransformerInterface
     /**
      * @param object|ReflectionClassConstant $reflection
      */
-    public function transform($reflection): ClassConstantReflectionInterface
+    public function transform($reflection): InterfaceConstantReflectionInterface
     {
         $docBlock = $this->docBlockFactory->create($reflection->getDocComment() ?: ' ');
 
-        return new ClassConstantReflection($reflection, $docBlock);
+        return new InterfaceConstantReflection($reflection, $docBlock);
     }
 }

--- a/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/ConstantTest.php
+++ b/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/ConstantTest.php
@@ -27,11 +27,11 @@ final class ConstantTest extends AbstractParserAwareTestCase
     {
         $ownConstants = $this->interfaceReflection->getOwnConstants();
         $this->assertCount(1, $ownConstants);
-        $this->assertInstanceOf(InterfaceConstantReflectionInterface::class, $ownConstants[0]);
+        $this->assertInstanceOf(InterfaceConstantReflectionInterface::class, $ownConstants['LAST']);
 
         $inheritedConstants = $this->interfaceReflection->getInheritedConstants();
         $this->assertCount(1, $inheritedConstants);
-        $this->assertInstanceOf(InterfaceConstantReflectionInterface::class, $inheritedConstants[0]);
+        $this->assertInstanceOf(InterfaceConstantReflectionInterface::class, $inheritedConstants['HOPE']);
 
         $this->assertNotSame($ownConstants, $inheritedConstants);
     }

--- a/packages/ThemeDefault/src/interface.latte
+++ b/packages/ThemeDefault/src/interface.latte
@@ -67,10 +67,10 @@
 
     {if $interface->getOwnConstants()}
         <table class="summary table table-responsive table-bordered table-striped" id="constants">
-            <tr><th>Constants Summary</th></tr>
+            <tr><th colspan="3">Constants Summary</th></tr>
             <tr n:foreach="$interface->getOwnConstants() as $constant" id="{$constant->getName()}">
                 <td class="attributes">
-                    <code>{$constant->getTypeHint()}</code>
+                    <code class="keyword">{$constant->getTypeHint()}</code>
                 </td>
                 <td class="name">
                     <code>
@@ -78,7 +78,7 @@
                     </code>
 
                     <div class="description">
-                        {$constant|description}
+                        {if $constant instanceof \ApiGen\Reflection\Contract\Reflection\Partial\AnnotationsInterface}{$constant|description}{/if}
 
                         {var $filteredAnnotations = ($constant->getAnnotations()|annotationFilter: ['var'])}
                         {foreach $filteredAnnotations as $annotation}

--- a/packages/ThemeDefault/src/partial/constant.latte
+++ b/packages/ThemeDefault/src/partial/constant.latte
@@ -1,6 +1,6 @@
 <tr id="{$constant->getName()}" n:class="$constant->isDeprecated() ? deprecated">
     <td class="attributes">
-        <code>
+        <code class="keyword">
         {if $constant->isPublic()}public{/if}
         {if $constant->isProtected()}protected{/if}
         {if $constant->isPrivate()}private{/if}
@@ -24,7 +24,7 @@
     <td class="value">
         <div>
             <a href="#{$constant->getName()}" class="anchor pull-right">#</a>
-            <code>{$constant->getValue()}</code>
+            <code>{$constant->getValueDefinition()}</code>
         </div>
     </td>
 </tr>

--- a/packages/ThemeDefault/src/partial/parentConstant.latte
+++ b/packages/ThemeDefault/src/partial/parentConstant.latte
@@ -1,5 +1,5 @@
 <td>
-    <code>
+    <code class="keyword">
         {foreach $parentClassOrInterface->getOwnConstants() as $parentClassOrInterfaceConstant}
             <a href="{$parentClassOrInterfaceConstant|linkReflection}" n:class="$parentClassOrInterfaceConstant->isDeprecated() ? deprecated, constant-name">
                 {$parentClassOrInterfaceConstant->getName()}


### PR DESCRIPTION
**Waits on PR <s>I am going to make into `BetterReflection`</s> Roave/BetterReflection#292.**


Also, we should get rid of
```
{if $constant instanceof \ApiGen\Reflection\Contract\Reflection\Partial\AnnotationsInterface}{$constant|description}{/if}
 ```
in templates. It is not the first case (it can be found in `function.latte`) so I propose to merge it as it is and then we should find another solution - maybe introduce some `DescriptionAwareInterface` for the latte filter....?