### PR TITLE
Typehints refactoring [WIP]

### DIFF
--- a/packages/Reflection/src/Contract/Reflection/AbstractParameterReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/AbstractParameterReflectionInterface.php
@@ -4,7 +4,7 @@ namespace ApiGen\Reflection\Contract\Reflection;
 
 interface AbstractParameterReflectionInterface extends AbstractReflectionInterface
 {
-    public function getTypeHint(): string;
+    public function getTypeHints(): array;
 
     public function isDefaultValueAvailable(): bool;
 

--- a/packages/Reflection/src/Contract/Reflection/AbstractParameterReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/AbstractParameterReflectionInterface.php
@@ -4,6 +4,9 @@ namespace ApiGen\Reflection\Contract\Reflection;
 
 interface AbstractParameterReflectionInterface extends AbstractReflectionInterface
 {
+    /**
+     * @return string[]
+     */
     public function getTypeHints(): array;
 
     public function isDefaultValueAvailable(): bool;

--- a/packages/Reflection/src/Contract/Reflection/Class_/ClassPropertyReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Class_/ClassPropertyReflectionInterface.php
@@ -16,7 +16,10 @@ interface ClassPropertyReflectionInterface extends AbstractClassElementInterface
      */
     public function getDefaultValue();
 
-    public function getTypeHint(): string;
+    /**
+     * @return string[]
+     */
+    public function getTypeHints(): array;
 
     public function getNamespaceName(): string;
 

--- a/packages/Reflection/src/Contract/Reflection/Trait_/TraitPropertyReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Trait_/TraitPropertyReflectionInterface.php
@@ -17,7 +17,10 @@ interface TraitPropertyReflectionInterface extends AbstractTraitElementInterface
      */
     public function getDefaultValue();
 
-    public function getTypeHint(): string;
+    /**
+     * @return string[]
+     */
+    public function getTypeHints(): array;
 
     public function getNamespaceName(): string;
 }

--- a/packages/Reflection/src/DocBlock/DocBlockFactory.php
+++ b/packages/Reflection/src/DocBlock/DocBlockFactory.php
@@ -45,7 +45,9 @@ final class DocBlockFactory
     }
 
     /**
-     * @param ReflectionClass|ReflectionMethod|ReflectionProperty $reflection
+     * Creates a context for proper type resolving.
+     *
+     * @param ReflectionClass|ReflectionMethod|ReflectionProperty|ReflectionFunction $reflection
      */
     private function createDocBlockContext($reflection): ?Context
     {

--- a/packages/Reflection/src/DocBlock/DocBlockFactory.php
+++ b/packages/Reflection/src/DocBlock/DocBlockFactory.php
@@ -8,7 +8,9 @@ use phpDocumentor\Reflection\DocBlock\DescriptionFactory;
 use phpDocumentor\Reflection\DocBlock\TagFactory;
 use phpDocumentor\Reflection\DocBlockFactory as PhpDocumentorDocBlockFactory;
 use phpDocumentor\Reflection\TypeResolver;
+use phpDocumentor\Reflection\Types\Context;
 use Roave\BetterReflection\Reflection\ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionFunction;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 
@@ -38,6 +40,22 @@ final class DocBlockFactory
      */
     public function createFromBetterReflection($classReflection): DocBlock
     {
-        return $this->phpDocumentorDocBlockFactory->create($classReflection->getDocComment() ?: ' ');
+        $context = $this->createDocBlockContext($classReflection);
+        return $this->phpDocumentorDocBlockFactory->create($classReflection->getDocComment() ?: ' ', $context);
+    }
+
+    /**
+     * @param ReflectionClass|ReflectionMethod|ReflectionProperty $reflection
+     */
+    private function createDocBlockContext($reflection): ?Context
+    {
+        if (! $reflection instanceof ReflectionClass && ! $reflection instanceof ReflectionFunction) {
+            $reflection = $reflection->getDeclaringClass();
+        }
+
+        return (new \phpDocumentor\Reflection\Types\ContextFactory())->createForNamespace(
+            $reflection->getNamespaceName(),
+            $reflection->getLocatedSource()->getSource()
+        );
     }
 }

--- a/packages/Reflection/src/Reflection/AbstractParameterReflection.php
+++ b/packages/Reflection/src/Reflection/AbstractParameterReflection.php
@@ -12,6 +12,8 @@ use ApiGen\Reflection\Contract\Reflection\Trait_\TraitMethodReflectionInterface;
 use ApiGen\Reflection\Contract\TransformerCollectorAwareInterface;
 use ApiGen\Reflection\TransformerCollector;
 use phpDocumentor\Reflection\DocBlock\Tags\Param;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Compound;
 use Roave\BetterReflection\Reflection\ReflectionParameter;
 
 abstract class AbstractParameterReflection implements AbstractParameterReflectionInterface, TransformerCollectorAwareInterface
@@ -32,26 +34,23 @@ abstract class AbstractParameterReflection implements AbstractParameterReflectio
     }
 
     /**
-     * @return string[]
+     * @return Type[]
      */
     public function getTypeHints(): array
     {
         $typeHint = $this->betterParameterReflection->getTypeHint();
-
         if ($typeHint) {
-            $typeHint = ltrim((string) $typeHint, '\\');
-            return [$typeHint];
+            return ($typeHint instanceof Compound)
+                ? iterator_to_array($typeHint->getIterator())
+                : [$typeHint];
         }
 
         $annotation = $this->getAnnotation();
         if ($annotation) {
-            $types = explode('|', (string) $annotation->getType());
-
-            array_walk($types, function (&$value) {
-                $value = ltrim((string) $value, '\\');
-            });
-
-            return $types;
+            $typeHint = $annotation->getType();
+            return ($typeHint instanceof Compound)
+                ? iterator_to_array($typeHint->getIterator())
+                : [$typeHint];
         }
 
         return [];

--- a/packages/Reflection/src/Reflection/AbstractParameterReflection.php
+++ b/packages/Reflection/src/Reflection/AbstractParameterReflection.php
@@ -31,6 +31,9 @@ abstract class AbstractParameterReflection implements AbstractParameterReflectio
         $this->betterParameterReflection = $betterParameterReflection;
     }
 
+    /**
+     * @return string[]
+     */
     public function getTypeHints(): array
     {
         $typeHint = $this->betterParameterReflection->getTypeHint();
@@ -64,7 +67,7 @@ abstract class AbstractParameterReflection implements AbstractParameterReflectio
     private function resolveTypes(array $types): array
     {
         array_walk($types, function (&$value) {
-           $value = ltrim($value, '\\');
+            $value = ltrim($value, '\\');
         });
 
         $function = $this->betterParameterReflection->getDeclaringFunction();
@@ -79,7 +82,7 @@ abstract class AbstractParameterReflection implements AbstractParameterReflectio
 
         $types = (new \Roave\BetterReflection\TypesFinder\ResolveTypes())->__invoke($types, $context);
         array_walk($types, function (&$value) {
-           $value = ltrim((string) $value, '\\');
+            $value = ltrim((string) $value, '\\');
         });
 
         return $types;

--- a/packages/Reflection/src/Reflection/AbstractParameterReflection.php
+++ b/packages/Reflection/src/Reflection/AbstractParameterReflection.php
@@ -46,46 +46,15 @@ abstract class AbstractParameterReflection implements AbstractParameterReflectio
         $annotation = $this->getAnnotation();
         if ($annotation) {
             $types = explode('|', (string) $annotation->getType());
-            return $this->resolveTypes($types);
+
+            array_walk($types, function (&$value) {
+                $value = ltrim((string) $value, '\\');
+            });
+
+            return $types;
         }
 
         return [];
-    }
-
-    /**
-     * Resolves fully-qualified class names in type hints.
-     *
-     * In BetterReflection library, there is no support (and shall not be)
-     * for unnamed `@param` annotations being defined by their index. For
-     * that reason, we need to process the annotations on our own. However,
-     * using the indexed `@param` annotations is not allowed by PSR-5, so
-     * it is possible to deprecate this function in the future.
-     *
-     * @param string[] $types
-     * @return string[]
-     */
-    private function resolveTypes(array $types): array
-    {
-        array_walk($types, function (&$value) {
-            $value = ltrim($value, '\\');
-        });
-
-        $function = $this->betterParameterReflection->getDeclaringFunction();
-        if ($function instanceof \Roave\BetterReflection\Reflection\ReflectionMethod) {
-            $function = $function->getDeclaringClass();
-        }
-
-        $context = (new \phpDocumentor\Reflection\Types\ContextFactory())->createForNamespace(
-            $function->getNamespaceName(),
-            $function->getLocatedSource()->getSource()
-        );
-
-        $types = (new \Roave\BetterReflection\TypesFinder\ResolveTypes())->__invoke($types, $context);
-        array_walk($types, function (&$value) {
-            $value = ltrim((string) $value, '\\');
-        });
-
-        return $types;
     }
 
     public function isDefaultValueAvailable(): bool

--- a/packages/Reflection/src/Reflection/AbstractParameterReflection.php
+++ b/packages/Reflection/src/Reflection/AbstractParameterReflection.php
@@ -31,20 +31,21 @@ abstract class AbstractParameterReflection implements AbstractParameterReflectio
         $this->betterParameterReflection = $betterParameterReflection;
     }
 
-    public function getTypeHint(): string
+    public function getTypeHints(): array
     {
-        $types = (string) $this->betterParameterReflection->getTypeHint();
-        $types = $this->removeClassPreSlashes($types);
-        if ($types) {
-            return $types;
+        $typeHint = $this->betterParameterReflection->getTypeHint();
+
+        if ($typeHint) {
+            $typeHint = ltrim((string) $typeHint, '\\');
+            return [$typeHint];
         }
 
-        $annotation = $this->getAnnotation();
-        if ($annotation) {
-            return (string) $annotation->getType();
+        $typeHints = [];
+        foreach ($this->betterParameterReflection->getDocBlockTypeStrings() as $typeHint) {
+            $typeHints[] = ltrim($typeHint, '\\');
         }
 
-        return '';
+        return $typeHints;
     }
 
     public function isDefaultValueAvailable(): bool
@@ -92,16 +93,6 @@ abstract class AbstractParameterReflection implements AbstractParameterReflectio
     public function setTransformerCollector(TransformerCollector $transformerCollector): void
     {
         $this->transformerCollector = $transformerCollector;
-    }
-
-    private function removeClassPreSlashes(string $types): string
-    {
-        $typesInArray = explode('|', $types);
-        array_walk($typesInArray, function (&$value) {
-            $value = ltrim($value, '\\');
-        });
-
-        return implode('|', $typesInArray);
     }
 
     private function getAnnotation(): ?Param

--- a/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
+++ b/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
@@ -8,7 +8,6 @@ use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
 use ApiGen\Reflection\Contract\TransformerCollectorAwareInterface;
 use ApiGen\Reflection\TransformerCollector;
 use phpDocumentor\Reflection\DocBlock;
-use phpDocumentor\Reflection\Types\Object_;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 
 final class ClassPropertyReflection implements ClassPropertyReflectionInterface, TransformerCollectorAwareInterface

--- a/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
+++ b/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
@@ -8,6 +8,8 @@ use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
 use ApiGen\Reflection\Contract\TransformerCollectorAwareInterface;
 use ApiGen\Reflection\TransformerCollector;
 use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Compound;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 
 final class ClassPropertyReflection implements ClassPropertyReflectionInterface, TransformerCollectorAwareInterface
@@ -84,16 +86,11 @@ final class ClassPropertyReflection implements ClassPropertyReflectionInterface,
     }
 
     /**
-     * @return string[]
+     * @return Type[]
      */
     public function getTypeHints(): array
     {
-        $typeHints = $this->betterPropertyReflection->getDocBlockTypeStrings();
-        foreach ($typeHints as $k => $typeHint) {
-            $typeHints[$k] = ltrim($typeHint, '\\');
-        }
-
-        return $typeHints;
+        return $this->betterPropertyReflection->getDocBlockTypes();
     }
 
     /**

--- a/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
+++ b/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
@@ -84,20 +84,17 @@ final class ClassPropertyReflection implements ClassPropertyReflectionInterface,
         return $this->betterPropertyReflection->getDefaultValue();
     }
 
-    public function getTypeHint(): string
+    /**
+     * @return string[]
+     */
+    public function getTypeHints(): array
     {
-        $typeHints = $this->betterPropertyReflection->getDocBlockTypes();
-        if (! count($typeHints)) {
-            return '';
+        $typeHints = $this->betterPropertyReflection->getDocBlockTypeStrings();
+        foreach ($typeHints as $k => $typeHint) {
+            $typeHints[$k] = ltrim($typeHint, '\\');
         }
 
-        $typeHint = $typeHints[0];
-        if ($typeHint instanceof Object_) {
-            $classOrInterfaceName = (string) $typeHint->getFqsen();
-            return ltrim($classOrInterfaceName, '\\');
-        }
-
-        return implode('|', $this->betterPropertyReflection->getDocBlockTypeStrings());
+        return $typeHints;
     }
 
     /**

--- a/packages/Reflection/src/Reflection/Trait_/TraitPropertyReflection.php
+++ b/packages/Reflection/src/Reflection/Trait_/TraitPropertyReflection.php
@@ -9,7 +9,6 @@ use ApiGen\Reflection\Contract\TransformerCollectorAwareInterface;
 use ApiGen\Reflection\TransformerCollector;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock\Tag;
-use phpDocumentor\Reflection\Types\Object_;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 
 final class TraitPropertyReflection implements TraitPropertyReflectionInterface, TransformerCollectorAwareInterface

--- a/packages/Reflection/src/Reflection/Trait_/TraitPropertyReflection.php
+++ b/packages/Reflection/src/Reflection/Trait_/TraitPropertyReflection.php
@@ -101,20 +101,17 @@ final class TraitPropertyReflection implements TraitPropertyReflectionInterface,
         return $this->betterPropertyReflection->getDefaultValue();
     }
 
-    public function getTypeHint(): string
+    /**
+     * @return string[]
+     */
+    public function getTypeHints(): array
     {
-        $typeHints = $this->betterPropertyReflection->getDocBlockTypes();
-        if (! count($typeHints)) {
-            return '';
+        $typeHints = $this->betterPropertyReflection->getDocBlockTypeStrings();
+        foreach ($typeHints as $k => $typeHint) {
+            $typeHints[$k] = ltrim($typeHint, '\\');
         }
 
-        $typeHint = $typeHints[0];
-        if ($typeHint instanceof Object_) {
-            $classOrInterfaceName = (string) $typeHint->getFqsen();
-            return ltrim($classOrInterfaceName, '\\');
-        }
-
-        return implode('|', $this->betterPropertyReflection->getDocBlockTypeStrings());
+        return $typeHints;
     }
 
     /**

--- a/packages/Reflection/src/Reflection/Trait_/TraitPropertyReflection.php
+++ b/packages/Reflection/src/Reflection/Trait_/TraitPropertyReflection.php
@@ -9,6 +9,8 @@ use ApiGen\Reflection\Contract\TransformerCollectorAwareInterface;
 use ApiGen\Reflection\TransformerCollector;
 use phpDocumentor\Reflection\DocBlock;
 use phpDocumentor\Reflection\DocBlock\Tag;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Compound;
 use Roave\BetterReflection\Reflection\ReflectionProperty;
 
 final class TraitPropertyReflection implements TraitPropertyReflectionInterface, TransformerCollectorAwareInterface
@@ -101,16 +103,11 @@ final class TraitPropertyReflection implements TraitPropertyReflectionInterface,
     }
 
     /**
-     * @return string[]
+     * @return Type[]
      */
     public function getTypeHints(): array
     {
-        $typeHints = $this->betterPropertyReflection->getDocBlockTypeStrings();
-        foreach ($typeHints as $k => $typeHint) {
-            $typeHints[$k] = ltrim($typeHint, '\\');
-        }
-
-        return $typeHints;
+        return $this->betterPropertyReflection->getDocBlockTypes();
     }
 
     /**

--- a/packages/Reflection/src/Transformer/BetterReflection/Class_/ClassConstantReflectionTransformer.php
+++ b/packages/Reflection/src/Transformer/BetterReflection/Class_/ClassConstantReflectionTransformer.php
@@ -4,18 +4,18 @@ namespace ApiGen\Reflection\Transformer\BetterReflection\Class_;
 
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassConstantReflectionInterface;
 use ApiGen\Reflection\Contract\Transformer\TransformerInterface;
+use ApiGen\Reflection\DocBlock\DocBlockFactory;
 use ApiGen\Reflection\Reflection\Class_\ClassConstantReflection;
-use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use Roave\BetterReflection\Reflection\ReflectionClassConstant;
 
 final class ClassConstantReflectionTransformer implements TransformerInterface
 {
     /**
-     * @var DocBlockFactoryInterface
+     * @var DocBlockFactory
      */
     private $docBlockFactory;
 
-    public function __construct(DocBlockFactoryInterface $docBlockFactory)
+    public function __construct(DocBlockFactory $docBlockFactory)
     {
         $this->docBlockFactory = $docBlockFactory;
     }
@@ -40,7 +40,7 @@ final class ClassConstantReflectionTransformer implements TransformerInterface
      */
     public function transform($reflection): ClassConstantReflectionInterface
     {
-        $docBlock = $this->docBlockFactory->create($reflection->getDocComment() ?: ' ');
+        $docBlock = $this->docBlockFactory->createFromBetterReflection($reflection);
 
         return new ClassConstantReflection($reflection, $docBlock);
     }

--- a/packages/Reflection/src/Transformer/BetterReflection/Class_/ClassReflectionTransformer.php
+++ b/packages/Reflection/src/Transformer/BetterReflection/Class_/ClassReflectionTransformer.php
@@ -7,8 +7,8 @@ use ApiGen\Element\Tree\SubClassesResolver;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
 use ApiGen\Reflection\Contract\Transformer\SortableTransformerInterface;
 use ApiGen\Reflection\Contract\Transformer\TransformerInterface;
+use ApiGen\Reflection\DocBlock\DocBlockFactory;
 use ApiGen\Reflection\Reflection\Class_\ClassReflection;
-use phpDocumentor\Reflection\DocBlockFactory;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 
 final class ClassReflectionTransformer implements TransformerInterface, SortableTransformerInterface
@@ -51,7 +51,7 @@ final class ClassReflectionTransformer implements TransformerInterface, Sortable
      */
     public function transform($reflection): ClassReflectionInterface
     {
-        $docBlock = $this->docBlockFactory->create($reflection->getDocComment() ?: ' ');
+        $docBlock = $this->docBlockFactory->createFromBetterReflection($reflection);
 
         return new ClassReflection(
             $reflection,

--- a/packages/Reflection/src/Transformer/BetterReflection/Function_/FunctionReflectionTransformer.php
+++ b/packages/Reflection/src/Transformer/BetterReflection/Function_/FunctionReflectionTransformer.php
@@ -4,8 +4,8 @@ namespace ApiGen\Reflection\Transformer\BetterReflection\Function_;
 
 use ApiGen\Reflection\Contract\Transformer\SortableTransformerInterface;
 use ApiGen\Reflection\Contract\Transformer\TransformerInterface;
+use ApiGen\Reflection\DocBlock\DocBlockFactory;
 use ApiGen\Reflection\Reflection\Function_\FunctionReflection;
-use phpDocumentor\Reflection\DocBlockFactory;
 use Roave\BetterReflection\Reflection\ReflectionFunction as BetterReflectionFunction;
 
 final class FunctionReflectionTransformer implements TransformerInterface, SortableTransformerInterface
@@ -33,7 +33,7 @@ final class FunctionReflectionTransformer implements TransformerInterface, Sorta
      */
     public function transform($reflection): FunctionReflection
     {
-        $docBlock = $this->docBlockFactory->create($reflection->getDocComment() ?: ' ');
+        $docBlock = $this->docBlockFactory->createFromBetterReflection($reflection);
 
         return new FunctionReflection($reflection, $docBlock);
     }

--- a/packages/Reflection/src/Transformer/BetterReflection/Interface_/InterfaceConstantReflectionTransformer.php
+++ b/packages/Reflection/src/Transformer/BetterReflection/Interface_/InterfaceConstantReflectionTransformer.php
@@ -4,18 +4,18 @@ namespace ApiGen\Reflection\Transformer\BetterReflection\Interface_;
 
 use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceConstantReflectionInterface;
 use ApiGen\Reflection\Contract\Transformer\TransformerInterface;
+use ApiGen\Reflection\DocBlock\DocBlockFactory;
 use ApiGen\Reflection\Reflection\Interface_\InterfaceConstantReflection;
-use phpDocumentor\Reflection\DocBlockFactoryInterface;
 use Roave\BetterReflection\Reflection\ReflectionClassConstant;
 
 final class InterfaceConstantReflectionTransformer implements TransformerInterface
 {
     /**
-     * @var DocBlockFactoryInterface
+     * @var DocBlockFactory
      */
     private $docBlockFactory;
 
-    public function __construct(DocBlockFactoryInterface $docBlockFactory)
+    public function __construct(DocBlockFactory $docBlockFactory)
     {
         $this->docBlockFactory = $docBlockFactory;
     }
@@ -39,7 +39,7 @@ final class InterfaceConstantReflectionTransformer implements TransformerInterfa
      */
     public function transform($reflection): InterfaceConstantReflectionInterface
     {
-        $docBlock = $this->docBlockFactory->create($reflection->getDocComment() ?: ' ');
+        $docBlock = $this->docBlockFactory->createFromBetterReflection($reflection);
 
         return new InterfaceConstantReflection($reflection, $docBlock);
     }

--- a/packages/Reflection/src/Transformer/BetterReflection/Interface_/InterfaceMethodReflectionTransformer.php
+++ b/packages/Reflection/src/Transformer/BetterReflection/Interface_/InterfaceMethodReflectionTransformer.php
@@ -3,8 +3,8 @@
 namespace ApiGen\Reflection\Transformer\BetterReflection\Interface_;
 
 use ApiGen\Reflection\Contract\Transformer\TransformerInterface;
+use ApiGen\Reflection\DocBlock\DocBlockFactory;
 use ApiGen\Reflection\Reflection\Interface_\InterfaceMethodReflection;
-use phpDocumentor\Reflection\DocBlockFactory;
 use Roave\BetterReflection\Reflection\ReflectionFunction as BetterReflectionFunction;
 use Roave\BetterReflection\Reflection\ReflectionMethod;
 
@@ -34,7 +34,7 @@ final class InterfaceMethodReflectionTransformer implements TransformerInterface
      */
     public function transform($reflection): InterfaceMethodReflection
     {
-        $docBlock = $this->docBlockFactory->create($reflection->getDocComment() ?: ' ');
+        $docBlock = $this->docBlockFactory->createFromBetterReflection($reflection);
 
         return new InterfaceMethodReflection($reflection, $docBlock);
     }

--- a/packages/Reflection/src/Transformer/BetterReflection/Interface_/InterfaceReflectionTransformer.php
+++ b/packages/Reflection/src/Transformer/BetterReflection/Interface_/InterfaceReflectionTransformer.php
@@ -5,8 +5,8 @@ namespace ApiGen\Reflection\Transformer\BetterReflection\Interface_;
 use ApiGen\Element\Tree\ImplementersResolver;
 use ApiGen\Reflection\Contract\Transformer\SortableTransformerInterface;
 use ApiGen\Reflection\Contract\Transformer\TransformerInterface;
+use ApiGen\Reflection\DocBlock\DocBlockFactory;
 use ApiGen\Reflection\Reflection\Interface_\InterfaceReflection;
-use phpDocumentor\Reflection\DocBlockFactory;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 
 final class InterfaceReflectionTransformer implements TransformerInterface, SortableTransformerInterface
@@ -40,7 +40,7 @@ final class InterfaceReflectionTransformer implements TransformerInterface, Sort
      */
     public function transform($reflection): InterfaceReflection
     {
-        $docBlock = $this->docBlockFactory->create($reflection->getDocComment() ?: ' ');
+        $docBlock = $this->docBlockFactory->createFromBetterReflection($reflection);
         return new InterfaceReflection($reflection, $docBlock, $this->implementersResolver);
     }
 }

--- a/packages/Reflection/src/Transformer/BetterReflection/Trait_/TraitReflectionTransformer.php
+++ b/packages/Reflection/src/Transformer/BetterReflection/Trait_/TraitReflectionTransformer.php
@@ -6,8 +6,8 @@ use ApiGen\Element\Tree\TraitUsersResolver;
 use ApiGen\Reflection\Contract\Reflection\Trait_\TraitReflectionInterface;
 use ApiGen\Reflection\Contract\Transformer\SortableTransformerInterface;
 use ApiGen\Reflection\Contract\Transformer\TransformerInterface;
+use ApiGen\Reflection\DocBlock\DocBlockFactory;
 use ApiGen\Reflection\Reflection\Trait_\TraitReflection;
-use phpDocumentor\Reflection\DocBlockFactory;
 use Roave\BetterReflection\Reflection\ReflectionClass;
 
 final class TraitReflectionTransformer implements TransformerInterface, SortableTransformerInterface
@@ -41,7 +41,7 @@ final class TraitReflectionTransformer implements TransformerInterface, Sortable
      */
     public function transform($reflection): TraitReflectionInterface
     {
-        $docBlock = $this->docBlockFactory->create($reflection->getDocComment() ?: ' ');
+        $docBlock = $this->docBlockFactory->createFromBetterReflection($reflection);
 
         return new TraitReflection($reflection, $docBlock, $this->traitUsersResolver);
     }

--- a/packages/Reflection/tests/Reflection/Class_/ClassPropertyReflection/ClassPropertyReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassPropertyReflection/ClassPropertyReflectionTest.php
@@ -37,9 +37,9 @@ final class ClassPropertyReflectionTest extends AbstractParserAwareTestCase
         $this->assertInstanceOf(ClassPropertyReflectionInterface::class, $this->propertyReflection);
     }
 
-    public function testGetTypeHint(): void
+    public function testGetTypeHints(): void
     {
-        $this->assertSame('int', $this->propertyReflection->getTypeHint());
+        $this->assertSame(['int'], $this->propertyReflection->getTypeHints());
     }
 
     public function testGetDeclaringClass(): void

--- a/packages/Reflection/tests/Reflection/Class_/ClassPropertyReflection/ClassPropertyReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassPropertyReflection/ClassPropertyReflectionTest.php
@@ -6,6 +6,7 @@ use ApiGen\Reflection\Contract\Reflection\Class_\ClassPropertyReflectionInterfac
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
 use ApiGen\Reflection\Tests\Reflection\Class_\ClassPropertyReflection\Source\ReflectionProperty;
 use ApiGen\Tests\AbstractParserAwareTestCase;
+use phpDocumentor\Reflection\Types\Integer;
 
 final class ClassPropertyReflectionTest extends AbstractParserAwareTestCase
 {
@@ -39,7 +40,9 @@ final class ClassPropertyReflectionTest extends AbstractParserAwareTestCase
 
     public function testGetTypeHints(): void
     {
-        $this->assertSame(['int'], $this->propertyReflection->getTypeHints());
+        $typeHints = $this->propertyReflection->getTypeHints();
+        $this->assertCount(1, $typeHints);
+        $this->assertInstanceOf(Integer::class, $typeHints[0]);
     }
 
     public function testGetDeclaringClass(): void

--- a/packages/Reflection/tests/Reflection/Class_/ClassPropertyReflection/ClassTypeHintPropertyTest.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassPropertyReflection/ClassTypeHintPropertyTest.php
@@ -6,6 +6,7 @@ use ApiGen\Reflection\Contract\Reflection\Class_\ClassPropertyReflectionInterfac
 use ApiGen\Reflection\Tests\Reflection\Class_\ClassPropertyReflection\Source\PropertyOfClassType;
 use ApiGen\Reflection\Tests\Reflection\Class_\ClassPropertyReflection\Source\ReflectionProperty;
 use ApiGen\Tests\AbstractParserAwareTestCase;
+use phpDocumentor\Reflection\Types\Object_;
 
 final class ClassTypeHintPropertyTest extends AbstractParserAwareTestCase
 {
@@ -25,6 +26,9 @@ final class ClassTypeHintPropertyTest extends AbstractParserAwareTestCase
 
     public function testGetTypeHint(): void
     {
-        $this->assertSame([PropertyOfClassType::class], $this->propertyReflection->getTypeHints());
+        $typeHints = $this->propertyReflection->getTypeHints();
+        $this->assertCount(1, $typeHints);
+        $this->assertInstanceOf(Object_::class, $typeHints[0]);
+        $this->assertSame('\\' . PropertyOfClassType::class, (string) $typeHints[0]->getFqsen());
     }
 }

--- a/packages/Reflection/tests/Reflection/Class_/ClassPropertyReflection/ClassTypeHintPropertyTest.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassPropertyReflection/ClassTypeHintPropertyTest.php
@@ -25,9 +25,6 @@ final class ClassTypeHintPropertyTest extends AbstractParserAwareTestCase
 
     public function testGetTypeHint(): void
     {
-        $this->assertSame(PropertyOfClassType::class, $this->propertyReflection->getTypeHint());
-
-        $typeHint = $this->propertyReflection->getTypeHint();
-        $this->assertSame(PropertyOfClassType::class, $typeHint);
+        $this->assertSame([PropertyOfClassType::class], $this->propertyReflection->getTypeHints());
     }
 }

--- a/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/ClassTypeTest.php
+++ b/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/ClassTypeTest.php
@@ -4,6 +4,7 @@ namespace ApiGen\Reflection\Tests\Reflection\Function_\FunctionParameterReflecti
 
 use ApiGen\Reflection\Contract\Reflection\Function_\FunctionParameterReflectionInterface;
 use ApiGen\Tests\AbstractParserAwareTestCase;
+use phpDocumentor\Reflection\Types\Object_;
 
 final class ClassTypeTest extends AbstractParserAwareTestCase
 {
@@ -29,6 +30,9 @@ final class ClassTypeTest extends AbstractParserAwareTestCase
 
     public function testType(): void
     {
-        $this->assertSame(['SplFileInfo'], $this->functionParameterReflection->getTypeHints());
+        $typeHints = $this->functionParameterReflection->getTypeHints();
+        $this->assertCount(1, $typeHints);
+        $this->assertInstanceOf(Object_::class, $typeHints[0]);
+        $this->assertSame('\SplFileInfo', (string) $typeHints[0]->getFqsen());
     }
 }

--- a/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/ClassTypeTest.php
+++ b/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/ClassTypeTest.php
@@ -29,6 +29,6 @@ final class ClassTypeTest extends AbstractParserAwareTestCase
 
     public function testType(): void
     {
-        $this->assertSame('SplFileInfo', $this->functionParameterReflection->getTypeHint());
+        $this->assertSame(['SplFileInfo'], $this->functionParameterReflection->getTypeHints());
     }
 }

--- a/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/ConstantDefaultValueTest.php
+++ b/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/ConstantDefaultValueTest.php
@@ -4,6 +4,7 @@ namespace ApiGen\Reflection\Tests\Reflection\Function_\FunctionParameterReflecti
 
 use ApiGen\Reflection\Contract\Reflection\Function_\FunctionParameterReflectionInterface;
 use ApiGen\Tests\AbstractParserAwareTestCase;
+use phpDocumentor\Reflection\Types\Integer;
 
 final class ConstantDefaultValueTest extends AbstractParserAwareTestCase
 {
@@ -29,7 +30,10 @@ final class ConstantDefaultValueTest extends AbstractParserAwareTestCase
 
     public function testType(): void
     {
-        $this->assertSame(['int'], $this->functionParameterReflection->getTypeHints());
+        $typeHints = $this->functionParameterReflection->getTypeHints();
+        $this->assertCount(1, $typeHints);
+        $this->assertInstanceOf(Integer::class, $typeHints[0]);
+
         // @todo - fix it after constant dump is fixed
         // $this->assertSame('HI', $this->functionParameterReflection->getDefaultValueDefinition());
     }

--- a/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/ConstantDefaultValueTest.php
+++ b/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/ConstantDefaultValueTest.php
@@ -29,7 +29,7 @@ final class ConstantDefaultValueTest extends AbstractParserAwareTestCase
 
     public function testType(): void
     {
-        $this->assertSame('int', $this->functionParameterReflection->getTypeHint());
+        $this->assertSame(['int'], $this->functionParameterReflection->getTypeHints());
         // @todo - fix it after constant dump is fixed
         // $this->assertSame('HI', $this->functionParameterReflection->getDefaultValueDefinition());
     }

--- a/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/FunctionParameterReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/FunctionParameterReflectionTest.php
@@ -5,6 +5,7 @@ namespace ApiGen\Reflection\Tests\Reflection\Function_\FunctionParameterReflecti
 use ApiGen\Reflection\Contract\Reflection\Function_\FunctionParameterReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Function_\FunctionReflectionInterface;
 use ApiGen\Tests\AbstractParserAwareTestCase;
+use phpDocumentor\Reflection\Types\String_;
 
 final class FunctionParameterReflectionTest extends AbstractParserAwareTestCase
 {
@@ -43,7 +44,10 @@ final class FunctionParameterReflectionTest extends AbstractParserAwareTestCase
 
     public function testType(): void
     {
-        $this->assertSame(['string'], $this->functionParameterReflection->getTypeHints());
+        $typeHints = $this->functionParameterReflection->getTypeHints();
+        $this->assertCount(1, $typeHints);
+        $this->assertInstanceOf(String_::class, $typeHints[0]);
+
         $this->assertTrue($this->functionParameterReflection->isVariadic());
         $this->assertFalse($this->functionParameterReflection->isArray());
         $this->assertFalse($this->functionParameterReflection->isCallable());

--- a/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/FunctionParameterReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/FunctionParameterReflectionTest.php
@@ -43,7 +43,7 @@ final class FunctionParameterReflectionTest extends AbstractParserAwareTestCase
 
     public function testType(): void
     {
-        $this->assertSame('string', $this->functionParameterReflection->getTypeHint());
+        $this->assertSame(['string'], $this->functionParameterReflection->getTypeHints());
         $this->assertTrue($this->functionParameterReflection->isVariadic());
         $this->assertFalse($this->functionParameterReflection->isArray());
         $this->assertFalse($this->functionParameterReflection->isCallable());

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/ClassParameterReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/ClassParameterReflectionTest.php
@@ -7,6 +7,7 @@ use ApiGen\Reflection\Contract\Reflection\Method\MethodParameterReflectionInterf
 use ApiGen\Reflection\Tests\Reflection\Method\MethodReflection\Source\ParameterClass;
 use ApiGen\Reflection\Tests\Reflection\Method\MethodReflection\Source\ParameterMethodClass;
 use ApiGen\Tests\AbstractParserAwareTestCase;
+use phpDocumentor\Reflection\Types\Object_;
 
 final class ClassParameterReflectionTest extends AbstractParserAwareTestCase
 {
@@ -32,6 +33,9 @@ final class ClassParameterReflectionTest extends AbstractParserAwareTestCase
 
     public function testGetTypeHint(): void
     {
-        $this->assertSame([ParameterClass::class], $this->parameterReflection->getTypeHints());
+        $typeHints = $this->parameterReflection->getTypeHints();
+        $this->assertCount(1, $typeHints);
+        $this->assertInstanceOf(Object_::class, $typeHints[0]);
+        $this->assertSame('\\' . ParameterClass::class, (string) $typeHints[0]->getFqsen());
     }
 }

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/ClassParameterReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/ClassParameterReflectionTest.php
@@ -32,6 +32,6 @@ final class ClassParameterReflectionTest extends AbstractParserAwareTestCase
 
     public function testGetTypeHint(): void
     {
-        $this->assertSame(ParameterClass::class, $this->parameterReflection->getTypeHint());
+        $this->assertSame([ParameterClass::class], $this->parameterReflection->getTypeHints());
     }
 }

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/MethodParameterReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/MethodParameterReflectionTest.php
@@ -7,6 +7,9 @@ use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Method\MethodParameterReflectionInterface;
 use ApiGen\Reflection\Tests\Reflection\Method\MethodReflection\Source\ParameterMethodClass;
 use ApiGen\Tests\AbstractParserAwareTestCase;
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\Object_;
+use phpDocumentor\Reflection\Types\String_;
 
 final class MethodParameterReflectionTest extends AbstractParserAwareTestCase
 {
@@ -37,7 +40,9 @@ final class MethodParameterReflectionTest extends AbstractParserAwareTestCase
 
     public function testGetTypeHints(): void
     {
-        $this->assertSame(['int', 'string'], $this->parameterReflection->getTypeHints());
+        $typeHints = $this->parameterReflection->getTypeHints();
+        $this->assertInstanceOf(Integer::class, $typeHints[0]);
+        $this->assertInstanceOf(String_::class, $typeHints[1]);
     }
 
     public function testGetIndexedTypeHints(): void
@@ -45,22 +50,33 @@ final class MethodParameterReflectionTest extends AbstractParserAwareTestCase
         $methodReflection = $this->classReflection->getMethod('methodWithIndexedTypeHints');
 
         $parameter = $methodReflection->getParameters()['param1'];
-        $this->assertSame(['int', 'string'], $parameter->getTypeHints());
+        $typeHints = $parameter->getTypeHints();
+        $this->assertInstanceOf(Integer::class, $typeHints[0]);
+        $this->assertInstanceOf(String_::class, $typeHints[1]);
 
         $parameter = $methodReflection->getParameters()['param2'];
-        $this->assertSame([
-            'ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection\Source\SomeClass'
-        ], $parameter->getTypeHints());
+        $typeHints = $parameter->getTypeHints();
+        $this->assertCount(1, $typeHints);
+        $this->assertInstanceOf(Object_::class, $typeHints[0]);
+        $this->assertSame('\ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection\Source\SomeClass', (string) $typeHints[0]->getFqsen());
 
         $parameter = $methodReflection->getParameters()['param3'];
-        $this->assertSame([
-            'ApiGen\Reflection\Tests\Reflection\Method\MethodReflection\Source\ParameterMethodClass'
-        ], $parameter->getTypeHints());
+        $typeHints = $parameter->getTypeHints();
+        $this->assertCount(1, $typeHints);
+        $this->assertInstanceOf(Object_::class, $typeHints[0]);
+        $this->assertSame(
+            '\ApiGen\Reflection\Tests\Reflection\Method\MethodReflection\Source\ParameterMethodClass',
+            (string) $typeHints[0]->getFqsen()
+        );
 
         $parameter = $methodReflection->getParameters()['param4'];
-        $this->assertSame([
-            'stdClass'
-        ], $parameter->getTypeHints());
+        $typeHints = $parameter->getTypeHints();
+        $this->assertCount(1, $typeHints);
+        $this->assertInstanceOf(Object_::class, $typeHints[0]);
+        $this->assertSame(
+            '\stdClass',
+            (string) $typeHints[0]->getFqsen()
+        );
     }
 
     public function testGetDescription(): void

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/MethodParameterReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/MethodParameterReflectionTest.php
@@ -56,6 +56,11 @@ final class MethodParameterReflectionTest extends AbstractParserAwareTestCase
         $this->assertSame([
             'ApiGen\Reflection\Tests\Reflection\Method\MethodReflection\Source\ParameterMethodClass'
         ], $parameter->getTypeHints());
+
+        $parameter = $methodReflection->getParameters()['param4'];
+        $this->assertSame([
+            'stdClass'
+        ], $parameter->getTypeHints());
     }
 
     public function testGetDescription(): void

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/MethodParameterReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/MethodParameterReflectionTest.php
@@ -37,7 +37,7 @@ final class MethodParameterReflectionTest extends AbstractParserAwareTestCase
 
     public function testGetTypeHint(): void
     {
-        $this->assertSame('int|string', $this->parameterReflection->getTypeHint());
+        $this->assertSame(['int', 'string'], $this->parameterReflection->getTypeHints());
     }
 
     public function testGetDescription(): void

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/MethodParameterReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/MethodParameterReflectionTest.php
@@ -35,9 +35,27 @@ final class MethodParameterReflectionTest extends AbstractParserAwareTestCase
         $this->assertInstanceOf(MethodParameterReflectionInterface::class, $this->parameterReflection);
     }
 
-    public function testGetTypeHint(): void
+    public function testGetTypeHints(): void
     {
         $this->assertSame(['int', 'string'], $this->parameterReflection->getTypeHints());
+    }
+
+    public function testGetIndexedTypeHints(): void
+    {
+        $methodReflection = $this->classReflection->getMethod('methodWithIndexedTypeHints');
+
+        $parameter = $methodReflection->getParameters()['param1'];
+        $this->assertSame(['int', 'string'], $parameter->getTypeHints());
+
+        $parameter = $methodReflection->getParameters()['param2'];
+        $this->assertSame([
+            'ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection\Source\SomeClass'
+        ], $parameter->getTypeHints());
+
+        $parameter = $methodReflection->getParameters()['param3'];
+        $this->assertSame([
+            'ApiGen\Reflection\Tests\Reflection\Method\MethodReflection\Source\ParameterMethodClass'
+        ], $parameter->getTypeHints());
     }
 
     public function testGetDescription(): void

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/ParameterWithConstantDefalutValueTest.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/ParameterWithConstantDefalutValueTest.php
@@ -5,6 +5,7 @@ namespace ApiGen\Reflection\Tests\Reflection\Method\MethodReflection;
 use ApiGen\Reflection\Contract\Reflection\Method\MethodParameterReflectionInterface;
 use ApiGen\Reflection\Tests\Reflection\Method\MethodReflection\Source\ParameterMethodClass;
 use ApiGen\Tests\AbstractParserAwareTestCase;
+use phpDocumentor\Reflection\Types\String_;
 
 final class ParameterWithConstantDefalutValueTest extends AbstractParserAwareTestCase
 {
@@ -31,8 +32,13 @@ final class ParameterWithConstantDefalutValueTest extends AbstractParserAwareTes
 
     public function testGetTypeHint(): void
     {
-        $this->assertSame(['string'], $this->localConstantParameterReflection->getTypeHints());
-        $this->assertSame(['string'], $this->classConstantParameterReflection->getTypeHints());
+        $typeHints = $this->localConstantParameterReflection->getTypeHints();
+        $this->assertCount(1, $typeHints);
+        $this->assertInstanceOf(String_::class, $typeHints[0]);
+
+        $typeHints = $this->classConstantParameterReflection->getTypeHints();
+        $this->assertCount(1, $typeHints);
+        $this->assertInstanceOf(String_::class, $typeHints[0]);
     }
 
     // @todo - fix after constant dump is fixed

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/ParameterWithConstantDefalutValueTest.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/ParameterWithConstantDefalutValueTest.php
@@ -31,8 +31,8 @@ final class ParameterWithConstantDefalutValueTest extends AbstractParserAwareTes
 
     public function testGetTypeHint(): void
     {
-        $this->assertSame('string', $this->localConstantParameterReflection->getTypeHint());
-        $this->assertSame('string', $this->classConstantParameterReflection->getTypeHint());
+        $this->assertSame(['string'], $this->localConstantParameterReflection->getTypeHints());
+        $this->assertSame(['string'], $this->classConstantParameterReflection->getTypeHints());
     }
 
     // @todo - fix after constant dump is fixed

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/Source/ParameterMethodClass.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/Source/ParameterMethodClass.php
@@ -26,8 +26,9 @@ class ParameterMethodClass
      * @param int|string
      * @param SomeClass
      * @param ParameterMethodClass
+     * @param \stdClass
      */
-    public function methodWithIndexedTypeHints($param1, $param2, $param3): void
+    public function methodWithIndexedTypeHints($param1, $param2, $param3, $param4): void
     {
     }
 

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/Source/ParameterMethodClass.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/Source/ParameterMethodClass.php
@@ -2,6 +2,8 @@
 
 namespace ApiGen\Reflection\Tests\Reflection\Method\MethodReflection\Source;
 
+use ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection\Source\SomeClass;
+
 class ParameterMethodClass
 {
     /**
@@ -17,6 +19,15 @@ class ParameterMethodClass
      * @param mixed[] $headers add optional headers
      */
     public function methodWithArgs($url = 1, $data = null, $headers = []): void
+    {
+    }
+
+    /**
+     * @param int|string
+     * @param SomeClass
+     * @param ParameterMethodClass
+     */
+    public function methodWithIndexedTypeHints($param1, $param2, $param3)
     {
     }
 

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/Source/ParameterMethodClass.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/Source/ParameterMethodClass.php
@@ -27,7 +27,7 @@ class ParameterMethodClass
      * @param SomeClass
      * @param ParameterMethodClass
      */
-    public function methodWithIndexedTypeHints($param1, $param2, $param3)
+    public function methodWithIndexedTypeHints($param1, $param2, $param3): void
     {
     }
 

--- a/packages/StringRouting/src/Latte/Filter/StringRoutingFiltersProvider.php
+++ b/packages/StringRouting/src/Latte/Filter/StringRoutingFiltersProvider.php
@@ -11,6 +11,8 @@ use ApiGen\StringRouting\Route\SourceCodeRoute;
 use ApiGen\StringRouting\StringRouter;
 use Nette\InvalidArgumentException;
 use Nette\Utils\Html;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Object_;
 
 final class StringRoutingFiltersProvider implements FilterProviderInterface
 {
@@ -53,17 +55,22 @@ final class StringRoutingFiltersProvider implements FilterProviderInterface
                 return $this->router->buildRoute(SourceCodeRoute::NAME, $reflection);
             },
 
-            // use in .latte: {$className|buildLinkIfReflectionFound}
-            'buildLinkIfReflectionFound' => function (string $className) {
-                $reflection = $this->reflectionStorage->getClassOrInterface($className);
-                if ($reflection) {
-                    $link = Html::el('a');
-                    $link->setAttribute('href', $this->router->buildRoute(ReflectionRoute::NAME, $reflection));
-                    $link->setText($className);
-                    return $link;
-                } else {
-                    return $className;
+            // use in .latte: {$type|buildLinkIfReflectionFound}
+            'buildLinkIfReflectionFound' => function (Type $type) {
+                if ($type instanceof Object_) {
+                    $className = (string) $type->getFqsen();
+                    $className = ltrim($className, "\\");
+                    $reflection = $this->reflectionStorage->getClassOrInterface($className);
+
+                    if ($reflection) {
+                        $link = Html::el('a');
+                        $link->setAttribute('href', $this->router->buildRoute(ReflectionRoute::NAME, $reflection));
+                        $link->setText($type->getFqsen()->getName());
+                        return $link;
+                    }
                 }
+
+                return (string) $type;
             }
         ];
     }

--- a/packages/StringRouting/tests/Latte/Filter/LinkFilterTest.php
+++ b/packages/StringRouting/tests/Latte/Filter/LinkFilterTest.php
@@ -8,6 +8,9 @@ use ApiGen\StringRouting\Tests\Latte\Filter\Source\TestClass;
 use ApiGen\Tests\AbstractContainerAwareTestCase;
 use Latte\Engine;
 use Nette\InvalidArgumentException;
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Types\Object_;
+use phpDocumentor\Reflection\Types\String_;
 
 final class LinkFilterTest extends AbstractContainerAwareTestCase
 {
@@ -41,7 +44,7 @@ final class LinkFilterTest extends AbstractContainerAwareTestCase
         $reflectionStorage = $this->container->get(ReflectionStorage::class);
 
         $html = $this->latte->renderToString(__DIR__ . '/Source/buildLinkIfReflectionFound-template.latte', [
-            'className' => TestClass::class,
+            'type' => new Object_(new Fqsen('\\' . TestClass::class)),
         ]);
         $this->assertSame(
             '<a href="class-ApiGen.StringRouting.Tests.Latte.Filter.Source.TestClass.html">'. TestClass::class . '</a>',
@@ -49,7 +52,7 @@ final class LinkFilterTest extends AbstractContainerAwareTestCase
         );
 
         $html = $this->latte->renderToString(__DIR__ . '/Source/buildLinkIfReflectionFound-template.latte', [
-            'className' => 'string',
+            'type' => new String_,
         ]);
         $this->assertSame('string', trim($html));
     }

--- a/packages/StringRouting/tests/Latte/Filter/Source/buildLinkIfReflectionFound-template.latte
+++ b/packages/StringRouting/tests/Latte/Filter/Source/buildLinkIfReflectionFound-template.latte
@@ -1,1 +1,1 @@
-{$className|buildLinkIfReflectionFound}
+{$type|buildLinkIfReflectionFound}

--- a/packages/ThemeDefault/src/function.latte
+++ b/packages/ThemeDefault/src/function.latte
@@ -40,7 +40,9 @@
             <tr n:foreach="$function->getParameters() as $parameter" id="${$parameter->getName()}">
                 <td class="name">
                     <code>
-                        {$parameter->getTypeHint()|buildLinkIfReflectionFound}
+                        {if $parameter->getTypeHints()}
+                            {foreach $parameter->getTypeHints() as $typeHint}{$typeHint|buildLinkIfReflectionFound}{sep}|{/sep}{/foreach}
+                        {/if}
                     </code>
                 </td>
                 <td class="value"><code>{block|strip}

--- a/packages/ThemeDefault/src/function.latte
+++ b/packages/ThemeDefault/src/function.latte
@@ -40,9 +40,7 @@
             <tr n:foreach="$function->getParameters() as $parameter" id="${$parameter->getName()}">
                 <td class="name">
                     <code>
-                        {if $parameter->getTypeHints()}
-                            {foreach $parameter->getTypeHints() as $typeHint}{$typeHint|buildLinkIfReflectionFound}{sep}|{/sep}{/foreach}
-                        {/if}
+                        {foreach $parameter->getTypeHints() as $typeHint}{$typeHint|buildLinkIfReflectionFound}{sep}|{/sep}{/foreach}
                     </code>
                 </td>
                 <td class="value"><code>{block|strip}

--- a/packages/ThemeDefault/src/partial/method.latte
+++ b/packages/ThemeDefault/src/partial/method.latte
@@ -24,7 +24,9 @@
                     <a href="{$method|linkSource}">{$method->getName()}</a>(
                     {foreach $method->getParameters() as $parameter}
                         <span>
-                            {$parameter->getTypeHint()|buildLinkIfReflectionFound}
+                            {if $parameter->getTypeHints()}
+                                {foreach $parameter->getTypeHints() as $typeHint}{$typeHint|buildLinkIfReflectionFound}{sep}|{/sep}{/foreach}
+                            {/if}
                             <span class="property-name">{if $parameter->isPassedByReference()}&amp; {/if}${$parameter->getName()}</span>
 
                         {if $parameter->isDefaultValueAvailable()} = {$parameter->getDefaultValue()|dumpDefaultValue|phpHighlight|noescape}{elseif $parameter->isVariadic()},…{/if}</span>{sep}, {/sep}

--- a/packages/ThemeDefault/src/partial/method.latte
+++ b/packages/ThemeDefault/src/partial/method.latte
@@ -24,9 +24,7 @@
                     <a href="{$method|linkSource}">{$method->getName()}</a>(
                     {foreach $method->getParameters() as $parameter}
                         <span>
-                            {if $parameter->getTypeHints()}
-                                {foreach $parameter->getTypeHints() as $typeHint}{$typeHint|buildLinkIfReflectionFound}{sep}|{/sep}{/foreach}
-                            {/if}
+                            {foreach $parameter->getTypeHints() as $typeHint}{$typeHint|buildLinkIfReflectionFound}{sep}|{/sep}{/foreach}
                             <span class="property-name">{if $parameter->isPassedByReference()}&amp; {/if}${$parameter->getName()}</span>
 
                         {if $parameter->isDefaultValueAvailable()} = {$parameter->getDefaultValue()|dumpDefaultValue|phpHighlight|noescape}{elseif $parameter->isVariadic()},…{/if}</span>{sep}, {/sep}

--- a/packages/ThemeDefault/src/partial/property.latte
+++ b/packages/ThemeDefault/src/partial/property.latte
@@ -3,9 +3,7 @@
         <code class="keyword">
             {if $property->isProtected()}protected{elseif $property->isPrivate()}private{else}public{/if} {if $property->isStatic()}static{/if}
 
-            {if count($property->getTypeHints())}
-                {foreach $property->getTypeHints() as $typehint}{$typehint|buildLinkIfReflectionFound}{sep}|{/sep}{/foreach}
-            {/if}
+            {foreach $property->getTypeHints() as $typehint}{$typehint|buildLinkIfReflectionFound}{sep}|{/sep}{/foreach}
         </code>
     </td>
 

--- a/packages/ThemeDefault/src/partial/property.latte
+++ b/packages/ThemeDefault/src/partial/property.latte
@@ -3,7 +3,9 @@
         <code class="keyword">
             {if $property->isProtected()}protected{elseif $property->isPrivate()}private{else}public{/if} {if $property->isStatic()}static{/if}
 
-            {$property->getTypeHint()|buildLinkIfReflectionFound}
+            {if count($property->getTypeHints())}
+                {foreach $property->getTypeHints() as $typehint}{$typehint|buildLinkIfReflectionFound}{sep}|{/sep}{/foreach}
+            {/if}
         </code>
     </td>
 


### PR DESCRIPTION
Allow multiple typehints as array. At the time, it does not support indexed parameters, it requires a name:

```php
/**
 * @param int $foo
 */
function a($foo)
{
}
```