### PR TITLE
[ecs] update to 2.2.6, make use of prepared configs

### DIFF
--- a/bin/bootstrap.php
+++ b/bin/bootstrap.php
@@ -1,18 +1,18 @@
 <?php declare(strict_types=1);
 
-$rootDir = realpath(__DIR__.'/../');
+$rootDir = realpath(__DIR__ . '/../');
 
 // Autoloader for standalone install (installed via `composer create-project` or cloned locally)
-$autoloader = realpath($rootDir.'/vendor/autoload.php');
+$autoloader = realpath($rootDir . '/vendor/autoload.php');
 
-if (!$autoloader) {
+if (! $autoloader) {
     // Installed via `composer [global] require`.
-    $autoloader = realpath($rootDir.'/../../autoload.php');
+    $autoloader = realpath($rootDir . '/../../autoload.php');
 }
 
-if (!$autoloader) {
+if (! $autoloader) {
     throw new RuntimeException(
-        'ApiGen was unable to find its autoloader. '.
+        'ApiGen was unable to find its autoloader. ' .
         'Did you forget to run "composer update"?'
     );
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "tracy/tracy": "^2.4",
         "phpunit/phpunit": "^6.0",
         "phpstan/phpstan": "^0.8",
-        "symplify/easy-coding-standard": "^2.2.3"
+        "symplify/easy-coding-standard": "^2.2"
     },
     "autoload": {
         "psr-4": {
@@ -69,8 +69,8 @@
     "scripts": {
         "complete-check": ["phpunit", "@phpstan", "@check-cs"],
         "phpstan": "phpstan analyse packages src bin --level 4 -c phpstan.neon",
-        "check-cs": "easy-coding-standard check packages bin src tests",
-        "fix-cs": "easy-coding-standard check packages bin src tests --fix"
+        "check-cs": "ecs check packages bin src tests",
+        "fix-cs": "ecs check packages bin src tests --fix"
     },
     "config": {
         "sort-packages": true

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -30,9 +30,10 @@ checkers:
     - PhpCsFixer\Fixer\LanguageConstruct\IsNullFixer
 
 parameters:
-    excluded_checkers:
+    exclude_checkers:
         - PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer
         - PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer
+        - PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer
 
     skip:
         SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff:
@@ -82,3 +83,6 @@ parameters:
             - packages/Reflection/src/Reflection/Interface_/InterfaceConstantReflection.php
             - packages/Reflection/src/Contract/Reflection/AbstractMethodReflectionInterface.php
             - *packages/Reflection/src/Contract/Reflection/*/*ReflectionInterface.php
+
+        Symplify\CodingStandard\Sniffs\Debug\CommentedOutCodeSniff:
+            - *packages/Annotation/src/AnnotationSubscriber/*Subscriber.php

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -35,6 +35,7 @@ parameters:
         - PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer
         - PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer
         - PhpCsFixer\Fixer\Operator\NewWithBracesFixer
+        - PhpCsFixer\Fixer\Phpdoc\PhpdocInlineTagFixer
         # possibly bugged: doesn't report errors, only fixes
         - Symplify\CodingStandard\Fixer\Php\ClassStringToClassConstantFixer
 
@@ -92,6 +93,8 @@ parameters:
             - *packages/Annotation/src/AnnotationSubscriber/*Subscriber.php
             - packages/Reflection/tests/Reflection/Method/MethodReflection/ParameterWithConstantDefalutValueTest.php
             - packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/ConstantDefaultValueTest.php
+            - packages/Reflection/src/Reflection/Interface_/InterfaceConstantReflection.php
+            - packages/Reflection/src/Reflection/Class_/ClassConstantReflection.php
 
         PhpCsFixer\Fixer\Phpdoc\PhpdocNoAliasTagFixer:
             # test
@@ -102,8 +105,11 @@ parameters:
             - packages/Element/tests/ReflectionCollector/Source/PartiallyDeprecatedClass.php
 
         Symplify\CodingStandard\Sniffs\Classes\EqualInterfaceImplementationSniff:
-            # todo: implement new interface
+            # todo: fix, add methods to parent interface or implement new interface
             - packages/Element/src/ReflectionCollector/NamespaceReflectionCollector.php
+            - packages/Reflection/src/Reflection/Class_/ClassConstantReflection.php
+            - packages/Reflection/src/Reflection/Class_/ClassReflection.php
+            - packages/Reflection/src/Reflection/Interface_/InterfaceConstantReflection.php
 
         Symplify\CodingStandard\Sniffs\Commenting\VarConstantCommentSniff:
             - packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/Source/functionWithConstant.php

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -92,3 +92,11 @@ parameters:
         PhpCsFixer\Fixer\Phpdoc\PhpdocNoAliasTagFixer:
             # test
             - packages/Annotation/tests/AnnotationSubscriber/LinkAnnotationSubscriberSource/SomeClassWithLinkAnnotations.php
+
+        PhpCsFixer\Fixer\ClassNotation\ProtectedToPrivateFixer:
+            # test
+            - packages/Element/tests/ReflectionCollector/Source/PartiallyDeprecatedClass.php
+
+        Symplify\CodingStandard\Sniffs\Classes\EqualInterfaceImplementationSniff:
+            # todo: implement new interface
+            - packages/Element/src/ReflectionCollector/NamespaceReflectionCollector.php

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -34,6 +34,7 @@ parameters:
         - PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer
         - PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer
         - PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer
+        - PhpCsFixer\Fixer\Operator\NewWithBracesFixer
         # possibly bugged: doesn't report errors, only fixes
         - Symplify\CodingStandard\Fixer\Php\ClassStringToClassConstantFixer
 
@@ -87,7 +88,10 @@ parameters:
             - *packages/Reflection/src/Contract/Reflection/*/*ReflectionInterface.php
 
         Symplify\CodingStandard\Sniffs\Debug\CommentedOutCodeSniff:
+            # todos, remove after they are fixed
             - *packages/Annotation/src/AnnotationSubscriber/*Subscriber.php
+            - packages/Reflection/tests/Reflection/Method/MethodReflection/ParameterWithConstantDefalutValueTest.php
+            - packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/ConstantDefaultValueTest.php
 
         PhpCsFixer\Fixer\Phpdoc\PhpdocNoAliasTagFixer:
             # test
@@ -100,3 +104,9 @@ parameters:
         Symplify\CodingStandard\Sniffs\Classes\EqualInterfaceImplementationSniff:
             # todo: implement new interface
             - packages/Element/src/ReflectionCollector/NamespaceReflectionCollector.php
+
+        Symplify\CodingStandard\Sniffs\Commenting\VarConstantCommentSniff:
+            - packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/Source/functionWithConstant.php
+
+        SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff:
+            - packages/Reflection/tests/Parser/DifferentVendorSources/vendor/autoload.php

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -34,6 +34,8 @@ parameters:
         - PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer
         - PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer
         - PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer
+        # possibly bugged: doesn't report errors, only fixes
+        - Symplify\CodingStandard\Fixer\Php\ClassStringToClassConstantFixer
 
     skip:
         SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff:
@@ -86,3 +88,7 @@ parameters:
 
         Symplify\CodingStandard\Sniffs\Debug\CommentedOutCodeSniff:
             - *packages/Annotation/src/AnnotationSubscriber/*Subscriber.php
+
+        PhpCsFixer\Fixer\Phpdoc\PhpdocNoAliasTagFixer:
+            # test
+            - packages/Annotation/tests/AnnotationSubscriber/LinkAnnotationSubscriberSource/SomeClassWithLinkAnnotations.php

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -1,68 +1,39 @@
 includes:
-    - vendor/symplify/easy-coding-standard/config/psr2-checkers.neon
+    - vendor/symplify/easy-coding-standard/config/php70-checkers.neon
+    - vendor/symplify/easy-coding-standard/config/php71-checkers.neon
+    - vendor/symplify/easy-coding-standard/config/symfony-checkers.neon
+    - vendor/symplify/easy-coding-standard/config/symplify-checkers.neon
+    - vendor/symplify/easy-coding-standard/config/common.neon
+    - vendor/symplify/easy-coding-standard/config/spaces.neon
 
 checkers:
-    # Solid
-    - Symplify\CodingStandard\Sniffs\Classes\FinalInterfaceSniff
-
     # PSR2
     PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff:
         absoluteLineLimit: 120
-    - PHP_CodeSniffer\Standards\PEAR\Sniffs\WhiteSpace\ScopeClosingBraceSniff
-    - PhpCsFixer\Fixer\ClassNotation\NoBlankLinesAfterClassOpeningFixer
-
-    # Comments
-    - Symplify\CodingStandard\Sniffs\Commenting\BlockPropertyCommentSniff
-
-    # Dev & Dead Code
-    - Symplify\CodingStandard\Sniffs\Debug\DebugFunctionCallSniff
-    - SlevomatCodingStandard\Sniffs\Classes\UnusedPrivateElementsSniff
-    PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer:
-         annotations:
-            - author
-            - expectedException
-
-    # Class Naming
-    - Symplify\CodingStandard\Sniffs\Naming\AbstractClassNameSniff
-    - Symplify\CodingStandard\Sniffs\Naming\InterfaceNameSniff
-    - Symplify\CodingStandard\Sniffs\Naming\TraitNameSniff
 
     # Code Structures
     - SlevomatCodingStandard\Sniffs\ControlStructures\AssignmentInConditionSniff
-    - SlevomatCodingStandard\Sniffs\ControlStructures\YodaComparisonSniff
 
     # Namespaces
-    - PhpCsFixer\Fixer\Import\NoUnusedImportsFixer
-    - SlevomatCodingStandard\Sniffs\Namespaces\UseFromSameNamespaceSniff
-    - SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff
-    - SlevomatCodingStandard\Sniffs\Namespaces\MultipleUsesPerLineSniff
-    - SlevomatCodingStandard\Sniffs\Namespaces\DisallowGroupUseSniff
-    - PhpCsFixer\Fixer\Import\OrderedImportsFixer
-
-    # Spacing
-    - PhpCsFixer\Fixer\ClassNotation\MethodSeparationFixer
+    SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff:
+        allowPartialUses: false
 
     # Strict and Scalar types
-    - PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer
     SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff:
         usefulAnnotations:
             - @dataProvider
             - @deprecated
             - @todo
         enableEachParameterAndReturnInspection: true
-    - SlevomatCodingStandard\Sniffs\TypeHints\NullableTypeForNullDefaultValueSniff
-    - SlevomatCodingStandard\Sniffs\TypeHints\ParameterTypeHintSpacingSniff
-    - SlevomatCodingStandard\Sniffs\TypeHints\ReturnTypeHintSpacingSniff
-    - SlevomatCodingStandard\Sniffs\TypeHints\LongTypeHintsSniff
-
-    PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
-         elements: [const, property, method]
 
     # new since PhpCsFixer 2.1/2.2
     - PhpCsFixer\Fixer\LanguageConstruct\IsNullFixer
-    - PhpCsFixer\Fixer\Basic\NonPrintableCharacterFixer
 
 parameters:
+    excluded_checkers:
+        - PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer
+        - PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer
+
     skip:
         SlevomatCodingStandard\Sniffs\TypeHints\TypeHintDeclarationSniff:
             # covariant implements

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -77,10 +77,6 @@ parameters:
         PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer:
             - tests/Generator/Source/SomeClass.php
 
-        PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer:
-            - packages/Reflection/tests/Reflection/Partial/Source/SomeClassWithAnnotations.php
-            - packages/Reflection/tests/Reflection/Class_/ClassReflection/Source/SomeClass.php
-
         PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff:
             - packages/Reflection/src/Reflection/AbstractParameterReflection.php
             - packages/Reflection/src/Reflection/Function_/FunctionParameterReflection.php
@@ -95,6 +91,9 @@ parameters:
             - packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/ConstantDefaultValueTest.php
             - packages/Reflection/src/Reflection/Interface_/InterfaceConstantReflection.php
             - packages/Reflection/src/Reflection/Class_/ClassConstantReflection.php
+            # useful notes
+            - src/Console/Progress/StepCounter.php
+            - tests/Console/Progress/StepCounterTest.php
 
         PhpCsFixer\Fixer\Phpdoc\PhpdocNoAliasTagFixer:
             # test
@@ -116,3 +115,4 @@ parameters:
 
         SlevomatCodingStandard\Sniffs\Namespaces\ReferenceUsedNamesOnlySniff:
             - packages/Reflection/tests/Parser/DifferentVendorSources/vendor/autoload.php
+            - tests/bootstrap.php

--- a/packages/Annotation/src/AnnotationDecorator.php
+++ b/packages/Annotation/src/AnnotationDecorator.php
@@ -7,7 +7,7 @@ use ApiGen\Reflection\Contract\Reflection\AbstractReflectionInterface;
 use phpDocumentor\Reflection\DocBlock\Tag;
 
 /**
- * @link https://github.com/phpDocumentor/TypeResolver#resolving-an-fqsen
+ * @see https://github.com/phpDocumentor/TypeResolver#resolving-an-fqsen
  */
 final class AnnotationDecorator
 {

--- a/packages/Annotation/src/AnnotationSubscriber/ReturnAnnotationSubscriber.php
+++ b/packages/Annotation/src/AnnotationSubscriber/ReturnAnnotationSubscriber.php
@@ -59,12 +59,14 @@ final class ReturnAnnotationSubscriber implements AnnotationSubscriberInterface
                 /** @var Object_ $objectValueType */
                 $objectValueType = $arrayType->getValueType();
                 $link = $this->createLinkFromObject($reflection, $objectValueType);
+
                 return '<code>' . $link . '[]</code>';
             }
         } elseif ($content->getType() instanceof Object_) {
             /** @var Object_ $objectValueType */
             $objectValueType = $content->getType();
             $link = $this->createLinkFromObject($reflection, $objectValueType);
+
             return '<code>' . $link . '</code>';
         }
 

--- a/packages/Annotation/src/AnnotationSubscriber/SeeUsesCoversAnnotationSubscriber.php
+++ b/packages/Annotation/src/AnnotationSubscriber/SeeUsesCoversAnnotationSubscriber.php
@@ -64,6 +64,7 @@ final class SeeUsesCoversAnnotationSubscriber implements AnnotationSubscriberInt
 
             if ($resolvedReflection instanceof AbstractReflectionInterface) {
                 $url = $this->reflectionRoute->constructUrl($resolvedReflection);
+
                 return '<code>' . $this->linkBuilder->build($url, ltrim($reference, '\\')) . '</code>';
             }
 

--- a/packages/Annotation/src/FqsenResolver/ElementResolver.php
+++ b/packages/Annotation/src/FqsenResolver/ElementResolver.php
@@ -77,6 +77,7 @@ final class ElementResolver
             $functionReflections = $this->reflectionStorage->getFunctionReflections();
 
             $namespacedFunctionName = $namespace . '\\' . $functionName;
+
             return $functionReflections[$namespacedFunctionName] ?? $namespacedFunctionName;
         }
 

--- a/packages/Annotation/src/Latte/Filter/AnnotationFilterProvider.php
+++ b/packages/Annotation/src/Latte/Filter/AnnotationFilterProvider.php
@@ -39,6 +39,7 @@ final class AnnotationFilterProvider implements FilterProviderInterface
             'description' => function (AnnotationsInterface $reflection) {
                 $processDocTextEvent = new ProcessDocTextEvent($reflection->getDescription(), $reflection);
                 $this->eventDispatcher->dispatch(ProcessDocTextEvent::class, $processDocTextEvent);
+
                 return $processDocTextEvent->getText();
             },
 
@@ -60,7 +61,7 @@ final class AnnotationFilterProvider implements FilterProviderInterface
                 }
 
                 return $annotations;
-            }
+            },
         ];
     }
 

--- a/packages/Annotation/tests/AnnotationSubscriber/LinkAnnotationSubscriberTest.php
+++ b/packages/Annotation/tests/AnnotationSubscriber/LinkAnnotationSubscriberTest.php
@@ -74,12 +74,12 @@ final class LinkAnnotationSubscriberTest extends AbstractParserAwareTestCase
             [
                 'http://php.net/session_set_save_handler',
                 '',
-                '<a href="http://php.net/session_set_save_handler">http://php.net/session_set_save_handler</a>'
+                '<a href="http://php.net/session_set_save_handler">http://php.net/session_set_save_handler</a>',
             ],
             [
                 'bitcoin:1335STSwu9hST4vcMRppEPgENMHD2r1REK',
                 'Donations',
-                '<a href="bitcoin:1335STSwu9hST4vcMRppEPgENMHD2r1REK">Donations</a>'
+                '<a href="bitcoin:1335STSwu9hST4vcMRppEPgENMHD2r1REK">Donations</a>',
             ],
             ['http://licence.com', 'MIT', '<a href="http://licence.com">MIT</a>'],
             ['https://apigen.org', 'Description', '<a href="https://apigen.org">Description</a>'],

--- a/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/SomeClassWithSeeAnnotations.php
+++ b/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/SomeClassWithSeeAnnotations.php
@@ -4,7 +4,7 @@ namespace ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSo
 
 use ApiGen\Annotation\Tests\AnnotationDecoratorSource\ReturnedClass;
 
-function someExistingFunction()
+function someExistingFunction(): void
 {
 }
 

--- a/packages/Annotation/tests/AnnotationSubscriber/Source/UsesCoversClass.php
+++ b/packages/Annotation/tests/AnnotationSubscriber/Source/UsesCoversClass.php
@@ -2,13 +2,11 @@
 
 namespace ApiGen\Annotation\Tests\AnnotationSubscriber\Source;
 
-use Nette\DI\ContainerBuilder;
-
 /**
- * @uses ContainerBuilder And the description
- * @covers ContainerBuilder::get()
+ * @uses \ContainerBuilder And the description
+ * @covers \ContainerBuilder::get()
  *
- * @uses UsedClass Not in link
+ * @uses \UsedClass Not in link
  */
 final class UsesCoversClass
 {

--- a/packages/Element/src/AutocompleteElements.php
+++ b/packages/Element/src/AutocompleteElements.php
@@ -51,7 +51,7 @@ final class AutocompleteElements
         foreach ($this->namespaceReflectionCollector->getNamespaces() as $namespace) {
             $elements[] = [
                 'file' => $this->namespaceRoute->constructUrl($namespace),
-                'label' => $namespace
+                'label' => $namespace,
             ];
         }
 
@@ -69,28 +69,28 @@ final class AutocompleteElements
             $path = $this->reflectionRoute->constructUrl($functionReflection);
             $elements[] = [
                'file' => $path,
-               'label' => $name
+               'label' => $name,
             ];
         }
 
         foreach ($this->reflectionStorage->getClassReflections() as $classReflection) {
             $elements[] = [
                 'file' => $this->reflectionRoute->constructUrl($classReflection),
-                'label' => $classReflection->getName()
+                'label' => $classReflection->getName(),
             ];
         }
 
         foreach ($this->reflectionStorage->getInterfaceReflections() as $interfaceReflection) {
             $elements[] = [
                 'file' => $this->reflectionRoute->constructUrl($interfaceReflection),
-                'label' => $interfaceReflection->getName()
+                'label' => $interfaceReflection->getName(),
             ];
         }
 
         foreach ($this->reflectionStorage->getTraitReflections() as $traitReflection) {
             $elements[] = [
                 'file' => $this->reflectionRoute->constructUrl($traitReflection),
-                'label' => $traitReflection->getName()
+                'label' => $traitReflection->getName(),
             ];
         }
 

--- a/packages/Element/src/Latte/Filter/DumpDefaultValueFilter.php
+++ b/packages/Element/src/Latte/Filter/DumpDefaultValueFilter.php
@@ -26,7 +26,7 @@ final class DumpDefaultValueFilter implements FilterProviderInterface
             // use in .latte: {$property->getDefaultValue()|dumpDefaultValue}
             'dumpDefaultValue' => function ($value) {
                 return $this->defaultValueDumper->dumpValue($value);
-            }
+            },
         ];
     }
 }

--- a/packages/Element/src/Latte/Filter/MethodReflectionNamingFilter.php
+++ b/packages/Element/src/Latte/Filter/MethodReflectionNamingFilter.php
@@ -28,7 +28,7 @@ final class MethodReflectionNamingFilter implements FilterProviderInterface
                 if ($methodReflection instanceof TraitMethodReflectionInterface) {
                     return $methodReflection->getDeclaringTraitName() . '::' . $methodReflection->getName() . '()';
                 }
-            }
+            },
         ];
     }
 }

--- a/packages/Element/src/Latte/Filter/PhpHighlightFilter.php
+++ b/packages/Element/src/Latte/Filter/PhpHighlightFilter.php
@@ -26,7 +26,7 @@ final class PhpHighlightFilter implements FilterProviderInterface
             // use in .latte: {$method|phpHighlight}
             'phpHighlight' => function ($code) {
                 return $this->highlighter->highlight($code);
-            }
+            },
         ];
     }
 }

--- a/packages/Element/src/ReflectionCollector/AnnotationReflectionCollector.php
+++ b/packages/Element/src/ReflectionCollector/AnnotationReflectionCollector.php
@@ -42,11 +42,6 @@ final class AnnotationReflectionCollector implements AdvancedReflectionCollector
         }
 
         foreach ($this->configuration->getAnnotationGroups() as $annotation) {
-            // @todo allow value as well?
-            // $reflection->hasAnnotation($annotation, $value);
-            // $reflection->hasAnnotation('@author', 'Tomas Votruba');
-            // url: annotation-author-tomasvotruba.html
-
             if (! $reflection->hasAnnotation($annotation)) {
                 continue;
             }

--- a/packages/Element/tests/Namespace_/ParentEmptyNamespacesResolverTest.php
+++ b/packages/Element/tests/Namespace_/ParentEmptyNamespacesResolverTest.php
@@ -38,7 +38,7 @@ final class ParentEmptyNamespacesResolverTest extends AbstractContainerAwareTest
         return [
             [['Parent', 'Parent\Namespace'], ['Parent\Namespace\SubNamespace']],
             [['Parent'], ['Parent\Namespace\SubNamespace', 'Parent\Namespace']],
-            [[], ['Parent', 'Parent\Namespace\SubNamespace', 'Parent\Namespace']]
+            [[], ['Parent', 'Parent\Namespace\SubNamespace', 'Parent\Namespace']],
         ];
     }
 }

--- a/packages/Element/tests/ReflectionCollector/AnnotationReflectionCollectorTest.php
+++ b/packages/Element/tests/ReflectionCollector/AnnotationReflectionCollectorTest.php
@@ -25,7 +25,7 @@ final class AnnotationReflectionCollectorTest extends AbstractContainerAwareTest
         $configuration->resolveOptions([
            SourceOption::NAME => [__DIR__],
            DestinationOption::NAME => TEMP_DIR,
-           AnnotationGroupsOption::NAME => [AnnotationList::DEPRECATED]
+           AnnotationGroupsOption::NAME => [AnnotationList::DEPRECATED],
         ]);
 
         /** @var Parser $parser */

--- a/packages/Element/tests/ReflectionCollector/Source/PartiallyDeprecatedClass.php
+++ b/packages/Element/tests/ReflectionCollector/Source/PartiallyDeprecatedClass.php
@@ -6,6 +6,7 @@ final class PartiallyDeprecatedClass
 {
     /**
      * @deprecated
+     * @var int
      */
     public const LEVEL = 0;
 

--- a/packages/ModularConfiguration/src/ConfigurationResolver.php
+++ b/packages/ModularConfiguration/src/ConfigurationResolver.php
@@ -28,17 +28,6 @@ final class ConfigurationResolver
         return $this->options[$name]->resolveValue($value);
     }
 
-    private function ensureOptionExists(string $name): void
-    {
-        if (! isset($this->options[$name])) {
-            throw new ConfigurationException(sprintf(
-                'Option "%s" was not found. Available options are: %s.',
-                $name,
-                array_keys($this->options)
-            ));
-        }
-    }
-
     /**
      * @param mixed[] $values
      * @return mixed[]
@@ -50,6 +39,17 @@ final class ConfigurationResolver
         }
 
         return $values;
+    }
+
+    private function ensureOptionExists(string $name): void
+    {
+        if (! isset($this->options[$name])) {
+            throw new ConfigurationException(sprintf(
+                'Option "%s" was not found. Available options are: %s.',
+                $name,
+                array_keys($this->options)
+            ));
+        }
     }
 
     /**

--- a/packages/ModularConfiguration/src/Option/ThemeDirectoryOption.php
+++ b/packages/ModularConfiguration/src/Option/ThemeDirectoryOption.php
@@ -42,7 +42,7 @@ final class ThemeDirectoryOption implements OptionInterface
 
         $candidates = [
             getcwd() . '/packages/ThemeDefault/src',
-            __DIR__ . '/../../../../packages/ThemeDefault/src'
+            __DIR__ . '/../../../../packages/ThemeDefault/src',
         ];
 
         foreach ($candidates as $candidate) {

--- a/packages/ModularConfiguration/src/Option/VisibilityLevelOption.php
+++ b/packages/ModularConfiguration/src/Option/VisibilityLevelOption.php
@@ -27,19 +27,19 @@ final class VisibilityLevelOption implements OptionInterface
      */
     public const PRIVATE = 'private';
 
-    public function getName(): string
-    {
-        return self::NAME;
-    }
-
     /**
      * @var int[]
      */
     private $nameToModificatorMap = [
         self::PUBLIC => ReflectionProperty::IS_PUBLIC,
         self::PROTECTED => ReflectionProperty::IS_PROTECTED,
-        self::PRIVATE => ReflectionProperty::IS_PRIVATE
+        self::PRIVATE => ReflectionProperty::IS_PRIVATE,
     ];
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
 
     /**
      * @param mixed $value

--- a/packages/Reflection/src/Contract/Reflection/Interface_/InterfaceConstantReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Interface_/InterfaceConstantReflectionInterface.php
@@ -2,7 +2,9 @@
 
 namespace ApiGen\Reflection\Contract\Reflection\Interface_;
 
-interface InterfaceConstantReflectionInterface extends AbstractInterfaceElementInterface
+use ApiGen\Reflection\Contract\Reflection\Partial\AnnotationsInterface;
+
+interface InterfaceConstantReflectionInterface extends AbstractInterfaceElementInterface, AnnotationsInterface
 {
     /**
      * @return mixed
@@ -10,4 +12,10 @@ interface InterfaceConstantReflectionInterface extends AbstractInterfaceElementI
     public function getValue();
 
     public function getTypeHint(): string;
+
+    public function isPublic(): bool;
+
+    public function isProtected(): bool;
+
+    public function isPrivate(): bool;
 }

--- a/packages/Reflection/src/Contract/Reflection/Trait_/TraitMethodReflectionInterface.php
+++ b/packages/Reflection/src/Contract/Reflection/Trait_/TraitMethodReflectionInterface.php
@@ -6,4 +6,5 @@ use ApiGen\Reflection\Contract\Reflection\AbstractMethodReflectionInterface;
 
 interface TraitMethodReflectionInterface extends AbstractMethodReflectionInterface, AbstractTraitElementInterface
 {
+    public function getOverriddenMethod(): ?TraitMethodReflectionInterface;
 }

--- a/packages/Reflection/src/DocBlock/Tags/See.php
+++ b/packages/Reflection/src/DocBlock/Tags/See.php
@@ -36,6 +36,11 @@ final class See extends BaseTag implements StaticMethod
         $this->description = $description;
     }
 
+    public function __toString(): string
+    {
+        return ($this->refers ?: $this->link) . ($this->description ? ' ' . $this->description->render() : '');
+    }
+
     /**
      * @param string $body
      */
@@ -71,10 +76,5 @@ final class See extends BaseTag implements StaticMethod
     public function getLink(): ?string
     {
         return $this->link;
-    }
-
-    public function __toString(): string
-    {
-        return ($this->refers ?: $this->link) . ($this->description ? ' ' . $this->description->render() : '');
     }
 }

--- a/packages/Reflection/src/Helper/ReflectionAnalyzer.php
+++ b/packages/Reflection/src/Helper/ReflectionAnalyzer.php
@@ -9,6 +9,7 @@ final class ReflectionAnalyzer
     public static function getReflectionInterfaceFromReflection(AbstractReflectionInterface $reflection): string
     {
         $implementedInterfaces = class_implements($reflection);
+
         return array_shift($implementedInterfaces);
     }
 }

--- a/packages/Reflection/src/Parser/Parser.php
+++ b/packages/Reflection/src/Parser/Parser.php
@@ -161,7 +161,7 @@ final class Parser
         foreach ($reflections as $reflection) {
             $class = $reflection;
             while ($parentClass = $class->getParentClass()) {
-                if (!isset($reflections[$parentClass->getName()])) {
+                if (! isset($reflections[$parentClass->getName()])) {
                     $reflections[$parentClass->getName()] = $parentClass;
                 }
 
@@ -180,7 +180,7 @@ final class Parser
     {
         foreach ($reflections as $reflection) {
             foreach ($reflection->getInterfaces() as $interface) {
-                if (!isset($reflections[$interface->getName()])) {
+                if (! isset($reflections[$interface->getName()])) {
                     $reflections[$interface->getName()] = $interface;
                 }
             }
@@ -197,7 +197,7 @@ final class Parser
     {
         foreach ($reflections as $reflection) {
             foreach ($reflection->getTraits() as $trait) {
-                if (!isset($reflections[$trait->getName()])) {
+                if (! isset($reflections[$trait->getName()])) {
                     $reflections[$trait->getName()] = $trait;
                 }
             }
@@ -227,8 +227,8 @@ final class Parser
     {
         $locators = [
             new DirectoriesSourceLocator($directories),
-            new AutoloadSourceLocator(),
-            new PhpInternalSourceLocator()
+            new AutoloadSourceLocator,
+            new PhpInternalSourceLocator,
         ];
 
         foreach ($directories as $directory) {
@@ -247,8 +247,8 @@ final class Parser
     private function createFilesSource(array $files): SourceLocator
     {
         $locators = [
-            new AutoloadSourceLocator(),
-            new PhpInternalSourceLocator()
+            new AutoloadSourceLocator,
+            new PhpInternalSourceLocator,
         ];
 
         foreach ($files as $file) {

--- a/packages/Reflection/src/Reflection/AbstractParameterReflection.php
+++ b/packages/Reflection/src/Reflection/AbstractParameterReflection.php
@@ -97,7 +97,7 @@ abstract class AbstractParameterReflection implements AbstractParameterReflectio
     private function removeClassPreSlashes(string $types): string
     {
         $typesInArray = explode('|', $types);
-        array_walk($typesInArray, function (&$value) {
+        array_walk($typesInArray, function (&$value): void {
             $value = ltrim($value, '\\');
         });
 

--- a/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
+++ b/packages/Reflection/src/Reflection/Class_/ClassPropertyReflection.php
@@ -94,6 +94,7 @@ final class ClassPropertyReflection implements ClassPropertyReflectionInterface,
         $typeHint = $typeHints[0];
         if ($typeHint instanceof Object_) {
             $classOrInterfaceName = (string) $typeHint->getFqsen();
+
             return ltrim($classOrInterfaceName, '\\');
         }
 

--- a/packages/Reflection/src/Reflection/Interface_/InterfaceConstantReflection.php
+++ b/packages/Reflection/src/Reflection/Interface_/InterfaceConstantReflection.php
@@ -136,4 +136,9 @@ final class InterfaceConstantReflection implements InterfaceConstantReflectionIn
     {
         $this->transformerCollector = $transformerCollector;
     }
+
+    public function getDescription(): string
+    {
+        return (string) $this->docBlock->getDescription();
+    }
 }

--- a/packages/Reflection/src/Reflection/Trait_/TraitMethodReflection.php
+++ b/packages/Reflection/src/Reflection/Trait_/TraitMethodReflection.php
@@ -61,11 +61,6 @@ final class TraitMethodReflection implements TraitMethodReflectionInterface, Tra
             ->getName();
     }
 
-    public function getNamespaceName(): string
-    {
-        // TODO: Implement getNamespaceName() method.
-    }
-
     public function isAbstract(): bool
     {
         return $this->betterMethodReflection->isAbstract();

--- a/packages/Reflection/src/Reflection/Trait_/TraitPropertyReflection.php
+++ b/packages/Reflection/src/Reflection/Trait_/TraitPropertyReflection.php
@@ -65,14 +65,12 @@ final class TraitPropertyReflection implements TraitPropertyReflectionInterface,
 
     public function getStartLine(): int
     {
-        // @todo
-        return 5;
+        return $this->betterPropertyReflection->getStartLine();
     }
 
     public function getEndLine(): int
     {
-        // @todo
-        return 5;
+        return $this->betterPropertyReflection->getEndLine();
     }
 
     public function getName(): string
@@ -111,6 +109,7 @@ final class TraitPropertyReflection implements TraitPropertyReflectionInterface,
         $typeHint = $typeHints[0];
         if ($typeHint instanceof Object_) {
             $classOrInterfaceName = (string) $typeHint->getFqsen();
+
             return ltrim($classOrInterfaceName, '\\');
         }
 

--- a/packages/Reflection/src/Reflection/Trait_/TraitReflection.php
+++ b/packages/Reflection/src/Reflection/Trait_/TraitReflection.php
@@ -130,16 +130,17 @@ final class TraitReflection implements TraitReflectionInterface, TransformerColl
     }
 
     /**
+     * Fails for now, see:
+     * https://github.com/nikic/PHP-Parser/issues/73#issuecomment-24533846
+     * $this->betterTraitReflection->getTraits();
+     * and PR with test
+     * https://github.com/Roave/BetterReflection/pull/274
+     *
      * @return TraitReflectionInterface[]
      */
     public function getTraits(): array
     {
         return [];
-        // fails for now, see:
-        // https://github.com/nikic/PHP-Parser/issues/73#issuecomment-24533846
-        // $this->betterTraitReflection->getTraits();
-        // and PR wit htest
-        // https://github.com/Roave/BetterReflection/pull/274
     }
 
     /**

--- a/packages/Reflection/src/Reflection/Trait_/TraitReflection.php
+++ b/packages/Reflection/src/Reflection/Trait_/TraitReflection.php
@@ -134,7 +134,7 @@ final class TraitReflection implements TraitReflectionInterface, TransformerColl
      * https://github.com/nikic/PHP-Parser/issues/73#issuecomment-24533846
      * $this->betterTraitReflection->getTraits();
      * and PR with test
-     * https://github.com/Roave/BetterReflection/pull/274
+     * https://github.com/Roave/BetterReflection/pull/274.
      *
      * @return TraitReflectionInterface[]
      */

--- a/packages/Reflection/src/ReflectionStorage.php
+++ b/packages/Reflection/src/ReflectionStorage.php
@@ -56,7 +56,7 @@ final class ReflectionStorage
      */
     public function addClassReflections(array $classReflections): void
     {
-        array_walk($classReflections, function (ClassReflectionInterface $classReflection) {
+        array_walk($classReflections, function (ClassReflectionInterface $classReflection): void {
         });
         sort($classReflections);
         foreach ($classReflections as $classReflection) {
@@ -81,7 +81,7 @@ final class ReflectionStorage
      */
     public function addInterfaceReflections(array $interfaceReflections): void
     {
-        array_walk($interfaceReflections, function (InterfaceReflectionInterface $interfaceReflection) {
+        array_walk($interfaceReflections, function (InterfaceReflectionInterface $interfaceReflection): void {
         });
         sort($interfaceReflections);
         foreach ($interfaceReflections as $interfaceReflection) {
@@ -102,7 +102,7 @@ final class ReflectionStorage
      */
     public function addTraitReflections(array $traitReflections): void
     {
-        array_walk($traitReflections, function (TraitReflectionInterface $traitReflection) {
+        array_walk($traitReflections, function (TraitReflectionInterface $traitReflection): void {
         });
         sort($traitReflections);
         foreach ($traitReflections as $traitReflection) {
@@ -123,7 +123,7 @@ final class ReflectionStorage
      */
     public function setFunctionReflections(array $functionReflections): void
     {
-        array_walk($functionReflections, function (FunctionReflectionInterface $functionReflection) {
+        array_walk($functionReflections, function (FunctionReflectionInterface $functionReflection): void {
         });
         sort($functionReflections);
 
@@ -148,6 +148,7 @@ final class ReflectionStorage
     public function getClassOrInterface(string $name)
     {
         $class = $this->getClass($name);
+
         return $class ?: $this->getInterface($name);
     }
 }

--- a/packages/Reflection/src/Transformer/BetterReflection/Interface_/InterfaceReflectionTransformer.php
+++ b/packages/Reflection/src/Transformer/BetterReflection/Interface_/InterfaceReflectionTransformer.php
@@ -41,6 +41,7 @@ final class InterfaceReflectionTransformer implements TransformerInterface, Sort
     public function transform($reflection): InterfaceReflection
     {
         $docBlock = $this->docBlockFactory->create($reflection->getDocComment() ?: ' ');
+
         return new InterfaceReflection($reflection, $docBlock, $this->implementersResolver);
     }
 }

--- a/packages/Reflection/src/TransformerCollector.php
+++ b/packages/Reflection/src/TransformerCollector.php
@@ -34,22 +34,6 @@ final class TransformerCollector
 
     /**
      * @param object[] $reflections
-     */
-    private function detectMatchingTransformer(array $reflections): ?TransformerInterface
-    {
-        $reflection = array_shift($reflections);
-
-        foreach ($this->transformers as $transformer) {
-            if ($transformer->matches($reflection)) {
-                return $transformer;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param object[] $reflections
      * @return object[]
      */
     public function transformGroup(array $reflections): array
@@ -107,6 +91,22 @@ final class TransformerCollector
     }
 
     /**
+     * @param object[] $reflections
+     */
+    private function detectMatchingTransformer(array $reflections): ?TransformerInterface
+    {
+        $reflection = array_shift($reflections);
+
+        foreach ($this->transformers as $transformer) {
+            if ($transformer->matches($reflection)) {
+                return $transformer;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @param object $transformedReflection
      */
     private function hasAllowedAccessLevel($transformedReflection): bool
@@ -128,18 +128,12 @@ final class TransformerCollector
      */
     private function shouldSkipReflection($transformedReflection): bool
     {
-        // also ! $this->reflection->isInternal();, remove isDocumented()
-
-        // @let decide voters if element is passed?
-        // here alreay 2 conditions
         if ($transformedReflection instanceof AnnotationsInterface
             && $transformedReflection->hasAnnotation('internal')
         ) {
             return true;
         }
 
-        // $this->configuration->getVisibilityLevels()
-        // @todo here is the place to filter out public/protected etc - use service!
         if (! $this->hasAllowedAccessLevel($transformedReflection)) {
             return true;
         }

--- a/packages/Reflection/tests/Parser/DifferentVendorSources/src/MyVendor/MyClass.php
+++ b/packages/Reflection/tests/Parser/DifferentVendorSources/src/MyVendor/MyClass.php
@@ -2,8 +2,8 @@
 
 namespace MyVendor;
 
-use DifferentVendor;
+use DifferentVendor\DifferentClass;
 
-class MyClass extends DifferentVendor\DifferentClass
+class MyClass extends DifferentClass
 {
 }

--- a/packages/Reflection/tests/Parser/DifferentVendorSources/vendor/autoload.php
+++ b/packages/Reflection/tests/Parser/DifferentVendorSources/vendor/autoload.php
@@ -1,13 +1,13 @@
 <?php declare(strict_types=1);
 
-$loader = new Composer\Autoload\ClassLoader();
+$loader = new Composer\Autoload\ClassLoader;
 
 // Files of the project that API is being generated for
 $loader->add('MyVendor', __DIR__ . '/../src');
 
 // Project's dependencies
 $loader->addClassMap([
-    'DifferentVendor\\DifferentClass' => __DIR__ . '/DifferentVendor/DifferentClass.php'
+    'DifferentVendor\\DifferentClass' => __DIR__ . '/DifferentVendor/DifferentClass.php',
 ]);
 
 $loader->register(true);

--- a/packages/Reflection/tests/Parser/ExtendingSources/ExtendingClass.php
+++ b/packages/Reflection/tests/Parser/ExtendingSources/ExtendingClass.php
@@ -2,9 +2,10 @@
 
 namespace ApiGen\Reflection\Tests\Parser\ExtendingSources;
 
-use ApiGen\Reflection\Tests\Parser\NotLoadedSources;
+use ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeClass;
+use ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeTrait;
 
-class ExtendingClass extends NotLoadedSources\SomeClass
+class ExtendingClass extends SomeClass
 {
-    use NotLoadedSources\SomeTrait;
+    // use SomeTrait;
 }

--- a/packages/Reflection/tests/Parser/ExtendingSources/ExtendingClass.php
+++ b/packages/Reflection/tests/Parser/ExtendingSources/ExtendingClass.php
@@ -6,5 +6,4 @@ use ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeClass;
 
 class ExtendingClass extends SomeClass
 {
-    // use SomeTrait;
 }

--- a/packages/Reflection/tests/Parser/ExtendingSources/ExtendingClass.php
+++ b/packages/Reflection/tests/Parser/ExtendingSources/ExtendingClass.php
@@ -3,7 +3,6 @@
 namespace ApiGen\Reflection\Tests\Parser\ExtendingSources;
 
 use ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeClass;
-use ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeTrait;
 
 class ExtendingClass extends SomeClass
 {

--- a/packages/Reflection/tests/Parser/ExtendingSources/ExtendingInterface.php
+++ b/packages/Reflection/tests/Parser/ExtendingSources/ExtendingInterface.php
@@ -2,8 +2,8 @@
 
 namespace ApiGen\Reflection\Tests\Parser\ExtendingSources;
 
-use ApiGen\Reflection\Tests\Parser\NotLoadedSources;
+use ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeInterface;
 
-interface ExtendingInterface extends NotLoadedSources\SomeInterface
+interface ExtendingInterface extends SomeInterface
 {
 }

--- a/packages/Reflection/tests/Parser/ExtendingSources/ExtendingTrait.php
+++ b/packages/Reflection/tests/Parser/ExtendingSources/ExtendingTrait.php
@@ -6,5 +6,5 @@ use ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeTrait;
 
 trait ExtendingTrait
 {
-    use SomeTrait;
+    // use SomeTrait;
 }

--- a/packages/Reflection/tests/Parser/ExtendingSources/ExtendingTrait.php
+++ b/packages/Reflection/tests/Parser/ExtendingSources/ExtendingTrait.php
@@ -2,9 +2,9 @@
 
 namespace ApiGen\Reflection\Tests\Parser\ExtendingSources;
 
-use ApiGen\Reflection\Tests\Parser\NotLoadedSources;
+use ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeTrait;
 
 trait ExtendingTrait
 {
-    use NotLoadedSources\SomeTrait;
+    use SomeTrait;
 }

--- a/packages/Reflection/tests/Parser/ExtendingSources/ExtendingTrait.php
+++ b/packages/Reflection/tests/Parser/ExtendingSources/ExtendingTrait.php
@@ -2,9 +2,6 @@
 
 namespace ApiGen\Reflection\Tests\Parser\ExtendingSources;
 
-use ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeTrait;
-
 trait ExtendingTrait
 {
-    // use SomeTrait;
 }

--- a/packages/Reflection/tests/Parser/ParentResolvingTest.php
+++ b/packages/Reflection/tests/Parser/ParentResolvingTest.php
@@ -3,7 +3,6 @@
 namespace ApiGen\Reflection\Tests\Parser;
 
 use ApiGen\Reflection\Parser\Parser;
-use ApiGen\Reflection\Reflection\Class_\ClassReflection;
 use ApiGen\Reflection\ReflectionStorage;
 use ApiGen\Tests\AbstractContainerAwareTestCase;
 
@@ -13,11 +12,6 @@ final class ParentResolvingTest extends AbstractContainerAwareTestCase
      * @var ReflectionStorage
      */
     private $reflectionStorage;
-
-    /**
-     * @var ClassReflection[]
-     */
-    private $allClasses;
 
     protected function setUp(): void
     {
@@ -36,7 +30,7 @@ final class ParentResolvingTest extends AbstractContainerAwareTestCase
         $this->assertArrayHasKey('ApiGen\Reflection\Tests\Parser\ExtendingSources\ExtendingClass', $allClasses);
     }
 
-    public function testInterfaces()
+    public function testInterfaces(): void
     {
         $allInterfaces = $this->reflectionStorage->getInterfaceReflections();
         $this->assertArrayHasKey('ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeInterface', $allInterfaces);
@@ -44,7 +38,7 @@ final class ParentResolvingTest extends AbstractContainerAwareTestCase
         $this->assertCount(2, $allInterfaces);
     }
 
-    public function testTraits()
+    public function testTraits(): void
     {
         $allTraits = $this->reflectionStorage->getTraitReflections();
         $this->assertArrayHasKey('ApiGen\Reflection\Tests\Parser\ExtendingSources\ExtendingTrait', $allTraits);

--- a/packages/Reflection/tests/Parser/ParentResolvingTest.php
+++ b/packages/Reflection/tests/Parser/ParentResolvingTest.php
@@ -3,33 +3,51 @@
 namespace ApiGen\Reflection\Tests\Parser;
 
 use ApiGen\Reflection\Parser\Parser;
+use ApiGen\Reflection\Reflection\Class_\ClassReflection;
 use ApiGen\Reflection\ReflectionStorage;
 use ApiGen\Tests\AbstractContainerAwareTestCase;
 
 final class ParentResolvingTest extends AbstractContainerAwareTestCase
 {
-    public function test(): void
+    /**
+     * @var ReflectionStorage
+     */
+    private $reflectionStorage;
+
+    /**
+     * @var ClassReflection[]
+     */
+    private $allClasses;
+
+    protected function setUp(): void
     {
         /** @var Parser $parser */
         $parser = $this->container->get(Parser::class);
         $parser->parseFilesAndDirectories([__DIR__ . '/ExtendingSources']);
 
-        $reflectionStorage = $this->container->get(ReflectionStorage::class);
+        $this->reflectionStorage = $this->container->get(ReflectionStorage::class);
+    }
 
-        $allClasses = $reflectionStorage->getClassReflections();
+    public function testClasses(): void
+    {
+        $allClasses = $this->reflectionStorage->getClassReflections();
+        $this->assertCount(2, $allClasses);
+        $this->assertArrayHasKey('ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeClass', $allClasses);
+        $this->assertArrayHasKey('ApiGen\Reflection\Tests\Parser\ExtendingSources\ExtendingClass', $allClasses);
+    }
 
-        self::assertCount(2, $allClasses);
-        self::assertArrayHasKey('ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeClass', $allClasses);
-        self::assertArrayHasKey('ApiGen\Reflection\Tests\Parser\ExtendingSources\ExtendingClass', $allClasses);
+    public function testInterfaces()
+    {
+        $allInterfaces = $this->reflectionStorage->getInterfaceReflections();
+        $this->assertArrayHasKey('ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeInterface', $allInterfaces);
+        $this->assertArrayHasKey('ApiGen\Reflection\Tests\Parser\ExtendingSources\ExtendingInterface', $allInterfaces);
+        $this->assertCount(2, $allInterfaces);
+    }
 
-        $allInterfaces = $reflectionStorage->getInterfaceReflections();
-        self::assertArrayHasKey('ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeInterface', $allInterfaces);
-        self::assertArrayHasKey('ApiGen\Reflection\Tests\Parser\ExtendingSources\ExtendingInterface', $allInterfaces);
-        self::assertCount(2, $allInterfaces);
-
-        $allTraits = $reflectionStorage->getTraitReflections();
-        self::assertArrayHasKey('ApiGen\Reflection\Tests\Parser\NotLoadedSources\SomeTrait', $allTraits);
-        self::assertArrayHasKey('ApiGen\Reflection\Tests\Parser\ExtendingSources\ExtendingTrait', $allTraits);
-        self::assertCount(2, $allTraits);
+    public function testTraits()
+    {
+        $allTraits = $this->reflectionStorage->getTraitReflections();
+        $this->assertArrayHasKey('ApiGen\Reflection\Tests\Parser\ExtendingSources\ExtendingTrait', $allTraits);
+        $this->assertCount(1, $allTraits);
     }
 }

--- a/packages/Reflection/tests/Parser/ParserTest.php
+++ b/packages/Reflection/tests/Parser/ParserTest.php
@@ -18,7 +18,7 @@ final class ParserTest extends AbstractContainerAwareTestCase
 
         $parser->parseFilesAndDirectories([
             __DIR__ . '/NotLoadedSources/SomeClass.php',
-            __DIR__ . '/AnotherSource'
+            __DIR__ . '/AnotherSource',
         ]);
 
         $classReflections = $reflectionStorage->getClassReflections();

--- a/packages/Reflection/tests/Reflection/Class_/ClassMethodReflection/Source/ClassMethod.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassMethodReflection/Source/ClassMethod.php
@@ -5,7 +5,7 @@ namespace ApiGen\Reflection\Tests\Reflection\Class_\ClassMethodReflection\Source
 final class ClassMethod
 {
     /**
-     * Send a POST request
+     * Send a POST request.
      *
      * @param int|string $url the URL of the API endpoint
      * @param mixed $data and array or a blob of data to be sent

--- a/packages/Reflection/tests/Reflection/Class_/ClassReflection/ClassReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassReflection/ClassReflectionTest.php
@@ -29,7 +29,7 @@ final class ClassReflectionTest extends AbstractParserAwareTestCase
 
     protected function setUp(): void
     {
-        /** @var Parser $parser */
+        // @var Parser $parser
         $this->parser->parseFilesAndDirectories([__DIR__ . '/Source']);
 
         $classReflections = $this->reflectionStorage->getClassReflections();
@@ -52,7 +52,7 @@ final class ClassReflectionTest extends AbstractParserAwareTestCase
     public function testAnnotations(): void
     {
         $this->assertSame(
-            'Huge and small' . PHP_EOL . PHP_EOL . 'description.',
+            'Huge and small.' . PHP_EOL . PHP_EOL . 'description.',
             $this->classReflection->getDescription()
         );
 

--- a/packages/Reflection/tests/Reflection/Class_/ClassReflection/MethodTest.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassReflection/MethodTest.php
@@ -34,7 +34,11 @@ final class MethodTest extends AbstractReflectionClassTestCase
 
         $methodsNames = array_keys($methods);
         $this->assertSame([
-            'publicMethod', 'protectedMethod', 'getSomeStuff', 'publicTraitMethod', 'getSomeParentStuff'
+            'publicMethod',
+            'getSomeStuff',
+            'protectedMethod',
+            'publicTraitMethod',
+            'getSomeParentStuff',
         ], $methodsNames);
     }
 

--- a/packages/Reflection/tests/Reflection/Class_/ClassReflection/Source/AccessLevels.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassReflection/Source/AccessLevels.php
@@ -5,8 +5,10 @@ namespace ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection\Source;
 final class AccessLevels extends ParentClass implements RichInterface
 {
     use SomeTrait;
-    // use SomeTraitNotPresentHere;
 
+    /**
+     * @var int
+     */
     public const LEVEL = 5;
 
     /**
@@ -14,12 +16,10 @@ final class AccessLevels extends ParentClass implements RichInterface
      */
     public $publicProperty;
 
-
     /**
      * @var mixed
      */
     protected $protectedProperty;
-
 
     /**
      * @var mixed
@@ -30,15 +30,15 @@ final class AccessLevels extends ParentClass implements RichInterface
     {
     }
 
+    public function getSomeStuff(): void
+    {
+    }
+
     protected function protectedMethod(): void
     {
     }
 
     private function privateMethod(): void
-    {
-    }
-
-    public function getSomeStuff(): void
     {
     }
 }

--- a/packages/Reflection/tests/Reflection/Class_/ClassReflection/Source/ParentClass.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassReflection/Source/ParentClass.php
@@ -4,6 +4,9 @@ namespace ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection\Source;
 
 class ParentClass
 {
+    /**
+     * @var int
+     */
     public const SOME_PARENT_CONSTANT = 123;
 
     /**

--- a/packages/Reflection/tests/Reflection/Class_/ClassReflection/Source/SomeClass.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassReflection/Source/SomeClass.php
@@ -3,7 +3,7 @@
 namespace ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection\Source;
 
 /**
- * Huge and small
+ * Huge and small.
  *
  * description.
  *
@@ -16,7 +16,7 @@ class SomeClass extends ParentClass
      */
     public $someProperty;
 
-    public function SomeMethod(): void
+    public function someMethod(): void
     {
     }
 }

--- a/packages/Reflection/tests/Reflection/Class_/ClassReflection/TraitsTest.php
+++ b/packages/Reflection/tests/Reflection/Class_/ClassReflection/TraitsTest.php
@@ -19,8 +19,6 @@ final class TraitsTest extends AbstractReflectionClassTestCase
         $this->assertCount(1, $traits);
 
         $this->assertInstanceOf(TraitReflectionInterface::class, $traits[SomeTrait::class]);
-        // temporary disabled due to phpstan autoloading, might not be needed
-        // $this->assertSame('Project\SomeTraitNotPresentHere', $traits['Project\SomeTraitNotPresentHere']);
     }
 
     public function testGetTraitAliases(): void

--- a/packages/Reflection/tests/Reflection/Common/Source/CommonReflection.php
+++ b/packages/Reflection/tests/Reflection/Common/Source/CommonReflection.php
@@ -5,12 +5,12 @@ namespace ApiGen\Reflection\Tests\Reflection\Common\Source;
 use ApiGen\Reflection\Tests\Reflection\Class_\ClassReflection\Source\SomeOtherClass;
 
 /**
- * This is some description
+ * This is some description.
  */
 class CommonReflection
 {
     /**
-     * Send a POST request
+     * Send a POST request.
      *
      * @param int|string $url the URL of the API endpoint
      * @param mixed $data and array or a blob of data to be sent

--- a/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/ConstantTest.php
+++ b/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/ConstantTest.php
@@ -6,7 +6,7 @@ use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceConstantReflection
 use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterface;
 use ApiGen\Reflection\Tests\Reflection\Interface_\InterfaceReflection\Source\SomeInterface;
 use ApiGen\Tests\AbstractParserAwareTestCase;
-use Exception;
+use Throwable;
 
 final class ConstantTest extends AbstractParserAwareTestCase
 {
@@ -54,7 +54,7 @@ final class ConstantTest extends AbstractParserAwareTestCase
 
     public function testMissingConstant(): void
     {
-        $this->expectException(Exception::class);
+        $this->expectException(Throwable::class);
         $this->interfaceReflection->getConstant('missing');
     }
 }

--- a/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/InterfaceReflectionTest.php
+++ b/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/InterfaceReflectionTest.php
@@ -59,7 +59,7 @@ final class InterfaceReflectionTest extends AbstractParserAwareTestCase
     public function testLines(): void
     {
         $this->assertSame(5, $this->interfaceReflection->getStartLine());
-        $this->assertSame(8, $this->interfaceReflection->getEndLine());
+        $this->assertSame(11, $this->interfaceReflection->getEndLine());
     }
 
     public function testFileName(): void

--- a/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/Source/PoorInterface.php
+++ b/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/Source/PoorInterface.php
@@ -4,6 +4,9 @@ namespace ApiGen\Reflection\Tests\Reflection\Interface_\InterfaceReflection\Sour
 
 interface PoorInterface
 {
+    /**
+     * @var string
+     */
     public const HOPE = 'do';
 
     public function riseAndShine(): void;

--- a/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/Source/SomeInterface.php
+++ b/packages/Reflection/tests/Reflection/Interface_/InterfaceReflection/Source/SomeInterface.php
@@ -4,5 +4,8 @@ namespace ApiGen\Reflection\Tests\Reflection\Interface_\InterfaceReflection\Sour
 
 interface SomeInterface extends RichInterface
 {
+    /**
+     * @var string
+     */
     public const LAST = 'live';
 }

--- a/packages/Reflection/tests/Reflection/Method/MethodReflection/Source/ParameterMethodClass.php
+++ b/packages/Reflection/tests/Reflection/Method/MethodReflection/Source/ParameterMethodClass.php
@@ -10,7 +10,7 @@ class ParameterMethodClass
     private const HERE = 'here';
 
     /**
-     * Send a POST request
+     * Send a POST request.
      *
      * @param int|string $url the URL of the API endpoint
      * @param mixed $data and array or a blob of data to be sent

--- a/packages/Reflection/tests/Reflection/Partial/AnnotationTest.php
+++ b/packages/Reflection/tests/Reflection/Partial/AnnotationTest.php
@@ -29,7 +29,7 @@ final class AnnotationTest extends AbstractParserAwareTestCase
 
     public function testGetDescription(): void
     {
-        $this->assertSame('This is some description', $this->reflection->getDescription());
+        $this->assertSame('This is some description.', $this->reflection->getDescription());
     }
 
     public function testGetAnnotations(): void

--- a/packages/Reflection/tests/Reflection/Partial/Source/SomeClassWithAnnotations.php
+++ b/packages/Reflection/tests/Reflection/Partial/Source/SomeClassWithAnnotations.php
@@ -3,7 +3,7 @@
 namespace ApiGen\Reflection\Tests\Reflection\Partial\Source;
 
 /**
- * This is some description
+ * This is some description.
  *
  * @see \ApiGen\Application\ApiGenApplication
  * @author Everyone.
@@ -12,7 +12,7 @@ namespace ApiGen\Reflection\Tests\Reflection\Partial\Source;
 class SomeClassWithAnnotations
 {
     /**
-     * Send a POST request
+     * Send a POST request.
      *
      * @param int|string $url the URL of the API endpoint
      * @param mixed $data and array or a blob of data to be sent

--- a/packages/Reflection/tests/Reflection/Trait_/TraitMethodReflection/Source/TraitMethodTrait.php
+++ b/packages/Reflection/tests/Reflection/Trait_/TraitMethodReflection/Source/TraitMethodTrait.php
@@ -5,7 +5,7 @@ namespace ApiGen\Reflection\Tests\Reflection\Trait_\TraitMethodReflection\Source
 trait TraitMethodTrait
 {
     /**
-     * Send a POST request
+     * Send a POST request.
      *
      * @param int|string $url the URL of the API endpoint
      * @param mixed $data and array or a blob of data to be sent

--- a/packages/Reflection/tests/Reflection/Trait_/TraitReflection/Source/SimpleTrait.php
+++ b/packages/Reflection/tests/Reflection/Trait_/TraitReflection/Source/SimpleTrait.php
@@ -4,7 +4,6 @@ namespace ApiGen\Reflection\Tests\Reflection\Trait_\TraitReflection\Source;
 
 trait SimpleTrait
 {
-    //use ParentTrait;
     use ToBeAliasedTrait {
         ToBeAliasedTrait::aliasedParentMethod as renamedMethod;
     }

--- a/packages/Reflection/tests/TransformerCollectorTest.php
+++ b/packages/Reflection/tests/TransformerCollectorTest.php
@@ -8,6 +8,21 @@ use Roave\BetterReflection\Reflection\ReflectionClass;
 
 final class TransformerCollectorTest extends AbstractContainerAwareTestCase
 {
+    public function testClassSorting(): void
+    {
+        $reflections = [
+            $this->createClassReflectionMock('ClassZ'),
+            $this->createClassReflectionMock('ClassA'),
+            $this->createClassReflectionMock('ClassX'),
+            $this->createClassReflectionMock('ClassB'),
+        ];
+
+        $transformerCollector = $this->container->get(TransformerCollector::class);
+        $elements = $transformerCollector->transformGroup($reflections);
+
+        $this->assertSame(['ClassA', 'ClassB', 'ClassX', 'ClassZ'], array_keys($elements));
+    }
+
     /**
      * @return object
      */
@@ -19,20 +34,5 @@ final class TransformerCollectorTest extends AbstractContainerAwareTestCase
         $reflection->method('isInterface')->willReturn(false);
 
         return $reflection;
-    }
-
-    public function testClassSorting(): void
-    {
-        $reflections = [
-            $this->createClassReflectionMock('ClassZ'),
-            $this->createClassReflectionMock('ClassA'),
-            $this->createClassReflectionMock('ClassX'),
-            $this->createClassReflectionMock('ClassB')
-        ];
-
-        $transformerCollector = $this->container->get(TransformerCollector::class);
-        $elements = $transformerCollector->transformGroup($reflections);
-
-        $this->assertSame(['ClassA', 'ClassB', 'ClassX', 'ClassZ'], array_keys($elements));
     }
 }

--- a/packages/StringRouting/src/Latte/Filter/StringRoutingFiltersProvider.php
+++ b/packages/StringRouting/src/Latte/Filter/StringRoutingFiltersProvider.php
@@ -44,12 +44,14 @@ final class StringRoutingFiltersProvider implements FilterProviderInterface
             // use in .latte: <a href="{$refleciton|linkReflection}">{$name}</a>
             'linkReflection' => function ($reflection): string {
                 $this->ensureFilterArgumentsIsReflection($reflection, 'linkReflection');
+
                 return $this->router->buildRoute(ReflectionRoute::NAME, $reflection);
             },
 
             // use in .latte: <a href="{$reflection|linkSource}">{$name}</a>
             'linkSource' => function ($reflection): string {
                 $this->ensureFilterArgumentsIsReflection($reflection, 'linkSource');
+
                 return $this->router->buildRoute(SourceCodeRoute::NAME, $reflection);
             },
 
@@ -60,11 +62,12 @@ final class StringRoutingFiltersProvider implements FilterProviderInterface
                     $link = Html::el('a');
                     $link->setAttribute('href', $this->router->buildRoute(ReflectionRoute::NAME, $reflection));
                     $link->setText($className);
+
                     return $link;
-                } else {
-                    return $className;
                 }
-            }
+
+                return $className;
+            },
         ];
     }
 

--- a/packages/StringRouting/tests/Latte/Filter/LinkFilterTest.php
+++ b/packages/StringRouting/tests/Latte/Filter/LinkFilterTest.php
@@ -44,7 +44,8 @@ final class LinkFilterTest extends AbstractContainerAwareTestCase
             'className' => TestClass::class,
         ]);
         $this->assertSame(
-            '<a href="class-ApiGen.StringRouting.Tests.Latte.Filter.Source.TestClass.html">' . TestClass::class . '</a>',
+            '<a href="class-ApiGen.StringRouting.Tests.Latte.Filter.Source.TestClass.html">'
+            . TestClass::class . '</a>',
             trim($html)
         );
 

--- a/packages/StringRouting/tests/Latte/Filter/LinkFilterTest.php
+++ b/packages/StringRouting/tests/Latte/Filter/LinkFilterTest.php
@@ -30,7 +30,7 @@ final class LinkFilterTest extends AbstractContainerAwareTestCase
         );
 
         $this->latte->renderToString(__DIR__ . '/Source/template.latte', [
-            'classReflection' => 'SomeClass'
+            'classReflection' => 'SomeClass',
         ]);
     }
 
@@ -44,7 +44,7 @@ final class LinkFilterTest extends AbstractContainerAwareTestCase
             'className' => TestClass::class,
         ]);
         $this->assertSame(
-            '<a href="class-ApiGen.StringRouting.Tests.Latte.Filter.Source.TestClass.html">'. TestClass::class . '</a>',
+            '<a href="class-ApiGen.StringRouting.Tests.Latte.Filter.Source.TestClass.html">' . TestClass::class . '</a>',
             trim($html)
         );
 

--- a/packages/StringRouting/tests/Route/ReflectionRouteTest.php
+++ b/packages/StringRouting/tests/Route/ReflectionRouteTest.php
@@ -121,7 +121,7 @@ final class ReflectionRouteTest extends AbstractContainerAwareTestCase
         return [
             [ClassConstantReflectionInterface::class, 'class-SomeClass.html#SomeName'],
             [ClassMethodReflectionInterface::class, 'class-SomeClass.html#_SomeName'],
-            [ClassPropertyReflectionInterface::class, 'class-SomeClass.html#$SomeName']
+            [ClassPropertyReflectionInterface::class, 'class-SomeClass.html#$SomeName'],
         ];
     }
 

--- a/packages/StringRouting/tests/Route/SourceCodeRouteTest.php
+++ b/packages/StringRouting/tests/Route/SourceCodeRouteTest.php
@@ -42,7 +42,7 @@ final class SourceCodeRouteTest extends AbstractContainerAwareTestCase
     {
         $reflectionClassMock = $this->createMock(ClassReflectionInterface::class);
         $reflectionClassMock->method('getName')
-            ->willReturn(\SomeNamespace\SomeName::class);
+            ->willReturn('SomeNamespace\SomeName');
 
         $this->assertSame(
             'source-class-SomeNamespace.SomeName.html',

--- a/packages/StringRouting/tests/Route/SourceCodeRouteTest.php
+++ b/packages/StringRouting/tests/Route/SourceCodeRouteTest.php
@@ -34,7 +34,7 @@ final class SourceCodeRouteTest extends AbstractContainerAwareTestCase
         $configuration = $this->container->get(Configuration::class);
         $configuration->resolveOptions([
             SourceOption::NAME => [__DIR__],
-            DestinationOption::NAME => TEMP_DIR
+            DestinationOption::NAME => TEMP_DIR,
         ]);
     }
 
@@ -42,7 +42,7 @@ final class SourceCodeRouteTest extends AbstractContainerAwareTestCase
     {
         $reflectionClassMock = $this->createMock(ClassReflectionInterface::class);
         $reflectionClassMock->method('getName')
-            ->willReturn('SomeNamespace\SomeName');
+            ->willReturn(\SomeNamespace\SomeName::class);
 
         $this->assertSame(
             'source-class-SomeNamespace.SomeName.html',
@@ -98,7 +98,7 @@ final class SourceCodeRouteTest extends AbstractContainerAwareTestCase
     public function provideDataForBuildLinedRoute(): array
     {
         return [
-            [FunctionReflectionInterface::class, 'source-function-SourceCodeRouteTest.php.html#15-25']
+            [FunctionReflectionInterface::class, 'source-function-SourceCodeRouteTest.php.html#15-25'],
         ];
     }
 
@@ -126,7 +126,7 @@ final class SourceCodeRouteTest extends AbstractContainerAwareTestCase
         return [
             [ClassConstantReflectionInterface::class, 'source-class-someClass.html#20-30'],
             [ClassMethodReflectionInterface::class, 'source-class-someClass.html#20-30'],
-            [ClassPropertyReflectionInterface::class, 'source-class-someClass.html#20-30']
+            [ClassPropertyReflectionInterface::class, 'source-class-someClass.html#20-30'],
         ];
     }
 

--- a/src/Application/ApiGenApplication.php
+++ b/src/Application/ApiGenApplication.php
@@ -49,7 +49,7 @@ final class ApiGenApplication
     {
         $options = $this->configuration->resolveOptions([
             SourceOption::NAME => $runCommand->getSource(),
-            DestinationOption::NAME => $runCommand->getDestination()
+            DestinationOption::NAME => $runCommand->getDestination(),
         ]);
 
         $this->parser->parseFilesAndDirectories($options[SourceOption::NAME]);

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -18,7 +18,7 @@ final class Configuration
     /**
      * @var mixed[]
      */
-    private $options;
+    private $options = [];
 
     /**
      * @var ParameterProvider

--- a/src/Console/Progress/StepCounter.php
+++ b/src/Console/Progress/StepCounter.php
@@ -68,7 +68,7 @@ final class StepCounter
         $count = 0;
         foreach ($reflections as $reflection) {
             if ($reflection->getFileName()) {
-                $count++;
+                ++$count;
             }
         }
 
@@ -79,23 +79,23 @@ final class StepCounter
     {
         $count = 2; // index.html + elementlist.js
         if (count($this->reflectionStorage->getClassReflections())) {
-            $count++; // classes.html
+            ++$count; // classes.html
         }
 
         if (count($this->reflectionStorage->getExceptionReflections())) {
-            $count++; // exceptions.html
+            ++$count; // exceptions.html
         }
 
         if (count($this->reflectionStorage->getInterfaceReflections())) {
-            $count++; // interfaces.html
+            ++$count; // interfaces.html
         }
 
         if (count($this->reflectionStorage->getTraitReflections())) {
-            $count++; // traits.html
+            ++$count; // traits.html
         }
 
         if (count($this->reflectionStorage->getFunctionReflections())) {
-            $count++; // functions.html
+            ++$count; // functions.html
         }
 
         return $count;

--- a/src/EventSubscriber/ConfigurationTemplateVariablesEventSubscriber.php
+++ b/src/EventSubscriber/ConfigurationTemplateVariablesEventSubscriber.php
@@ -24,7 +24,7 @@ final class ConfigurationTemplateVariablesEventSubscriber implements EventSubscr
     public static function getSubscribedEvents(): array
     {
         return [
-            CreateTemplateEvent::class => 'loadTemplateVariables'
+            CreateTemplateEvent::class => 'loadTemplateVariables',
         ];
     }
 
@@ -33,7 +33,7 @@ final class ConfigurationTemplateVariablesEventSubscriber implements EventSubscr
         $parameterBag = $createTemplateEvent->getParameterBag();
         $parameterBag->addParameters([
             'title' => $this->configuration->getTitle(),
-            'annotationGroups' => $this->configuration->getAnnotationGroups()
+            'annotationGroups' => $this->configuration->getAnnotationGroups(),
         ]);
     }
 }

--- a/src/EventSubscriber/ElementsTemplateVariablesEventSubscriber.php
+++ b/src/EventSubscriber/ElementsTemplateVariablesEventSubscriber.php
@@ -33,7 +33,7 @@ final class ElementsTemplateVariablesEventSubscriber implements EventSubscriberI
     public static function getSubscribedEvents(): array
     {
         return [
-            CreateTemplateEvent::class => 'loadTemplateVariables'
+            CreateTemplateEvent::class => 'loadTemplateVariables',
         ];
     }
 
@@ -56,7 +56,7 @@ final class ElementsTemplateVariablesEventSubscriber implements EventSubscriberI
             'allExceptions' => $this->reflectionStorage->getExceptionReflections(),
             'allInterfaces' => $this->reflectionStorage->getInterfaceReflections(),
             'allTraits' => $this->reflectionStorage->getTraitReflections(),
-            'allFunctions' => $this->reflectionStorage->getFunctionReflections()
+            'allFunctions' => $this->reflectionStorage->getFunctionReflections(),
         ]);
     }
 }

--- a/src/EventSubscriber/ProgressBarEventSubscriber.php
+++ b/src/EventSubscriber/ProgressBarEventSubscriber.php
@@ -24,7 +24,7 @@ final class ProgressBarEventSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            GenerateProgressEvent::class => 'generateProgress'
+            GenerateProgressEvent::class => 'generateProgress',
         ];
     }
 

--- a/src/Generator/AnnotationGroupsGenerator.php
+++ b/src/Generator/AnnotationGroupsGenerator.php
@@ -49,13 +49,13 @@ final class AnnotationGroupsGenerator implements GeneratorInterface
             [
                 'annotation' => $annotation,
                 'activePage' => 'annotation-group-' . $annotation,
-                'hasElements' =>  $this->annotationReflectionCollector->hasAnyElements(),
+                'hasElements' => $this->annotationReflectionCollector->hasAnyElements(),
                 'classes' => $this->annotationReflectionCollector->getClassReflections($annotation),
                 'interfaces' => $this->annotationReflectionCollector->getInterfaceReflections($annotation),
                 'traits' => $this->annotationReflectionCollector->getTraitReflections($annotation),
                 'methods' => $this->annotationReflectionCollector->getClassOrTraitMethodReflections($annotation),
                 'functions' => $this->annotationReflectionCollector->getFunctionReflections($annotation),
-                'properties' => $this->annotationReflectionCollector->getClassOrTraitPropertyReflections($annotation)
+                'properties' => $this->annotationReflectionCollector->getClassOrTraitPropertyReflections($annotation),
             ]
         );
     }

--- a/src/Generator/AutoCompleteDataGenerator.php
+++ b/src/Generator/AutoCompleteDataGenerator.php
@@ -40,7 +40,7 @@ final class AutoCompleteDataGenerator implements GeneratorInterface
             $this->configuration->getTemplatesDirectory() . DIRECTORY_SEPARATOR . 'elementlist.js.latte',
             $this->configuration->getDestination() . DIRECTORY_SEPARATOR . 'elementlist.js',
             [
-                'autocompleteElements' => $this->autocompleteElements->getElements()
+                'autocompleteElements' => $this->autocompleteElements->getElements(),
             ]
         );
     }

--- a/src/Generator/ClassGenerator.php
+++ b/src/Generator/ClassGenerator.php
@@ -77,7 +77,7 @@ final class ClassGenerator implements GeneratorInterface
                 'activePage' => 'class',
                 'activeClass' => $classReflection,
                 'fileName' => $classReflection->getFileName(),
-                'source' => $highlightedContent
+                'source' => $highlightedContent,
             ]
         );
     }

--- a/src/Generator/ClassesGenerator.php
+++ b/src/Generator/ClassesGenerator.php
@@ -51,7 +51,7 @@ final class ClassesGenerator implements GeneratorInterface
             [
                 'activePage' => self::NAME,
                 'pageTitle' => ucfirst(self::NAME),
-                self::NAME => $this->reflectionStorage->getClassReflections()
+                self::NAME => $this->reflectionStorage->getClassReflections(),
             ]
         );
     }

--- a/src/Generator/ExceptionGenerator.php
+++ b/src/Generator/ExceptionGenerator.php
@@ -77,7 +77,7 @@ final class ExceptionGenerator implements GeneratorInterface
                 'activePage' => 'class',
                 'activeClass' => $exceptionReflection,
                 'fileName' => $exceptionReflection->getFileName(),
-                'source' => $highlightedContent
+                'source' => $highlightedContent,
             ]
         );
     }

--- a/src/Generator/ExceptionsGenerator.php
+++ b/src/Generator/ExceptionsGenerator.php
@@ -51,7 +51,7 @@ final class ExceptionsGenerator implements GeneratorInterface
             [
                 'activePage' => self::NAME,
                 'pageTitle' => ucfirst(self::NAME),
-                self::NAME => $this->reflectionStorage->getExceptionReflections()
+                self::NAME => $this->reflectionStorage->getExceptionReflections(),
             ]
         );
     }

--- a/src/Generator/FunctionGenerator.php
+++ b/src/Generator/FunctionGenerator.php
@@ -68,7 +68,7 @@ final class FunctionGenerator implements GeneratorInterface
             $this->configuration->getDestinationWithPrefixName('function-', $reflectionFunction->getName()),
             [
                 'activePage' => 'function',
-                'function' => $reflectionFunction
+                'function' => $reflectionFunction,
             ]
         );
     }

--- a/src/Generator/FunctionsGenerator.php
+++ b/src/Generator/FunctionsGenerator.php
@@ -51,7 +51,7 @@ final class FunctionsGenerator implements GeneratorInterface
             [
                 'activePage' => self::NAME,
                 'pageTitle' => ucfirst(self::NAME),
-                self::NAME => $this->reflectionStorage->getFunctionReflections()
+                self::NAME => $this->reflectionStorage->getFunctionReflections(),
             ]
         );
     }

--- a/src/Generator/IndexGenerator.php
+++ b/src/Generator/IndexGenerator.php
@@ -30,7 +30,7 @@ final class IndexGenerator implements GeneratorInterface
             $this->configuration->getTemplateByName('index'),
             $this->configuration->getDestinationWithName('index'),
             [
-                'activePage' => 'overview'
+                'activePage' => 'overview',
             ]
         );
     }

--- a/src/Generator/InterfacesGenerator.php
+++ b/src/Generator/InterfacesGenerator.php
@@ -51,7 +51,7 @@ final class InterfacesGenerator implements GeneratorInterface
             [
                 'activePage' => self::NAME,
                 'pageTitle' => ucfirst(self::NAME),
-                self::NAME => $this->reflectionStorage->getInterfaceReflections()
+                self::NAME => $this->reflectionStorage->getInterfaceReflections(),
             ]
         );
     }

--- a/src/Generator/NamespaceGenerator.php
+++ b/src/Generator/NamespaceGenerator.php
@@ -56,7 +56,7 @@ final class NamespaceGenerator implements GeneratorInterface
                 'exceptions' => $namespaceReflectionCollector->getExceptionReflections($namespace),
                 'interfaces' => $namespaceReflectionCollector->getInterfaceReflections($namespace),
                 'traits' => $namespaceReflectionCollector->getTraitReflections($namespace),
-                'functions' => $namespaceReflectionCollector->getFunctionReflections($namespace)
+                'functions' => $namespaceReflectionCollector->getFunctionReflections($namespace),
             ]
         );
     }

--- a/src/Generator/TraitsGenerator.php
+++ b/src/Generator/TraitsGenerator.php
@@ -51,7 +51,7 @@ final class TraitsGenerator implements GeneratorInterface
             [
                 'activePage' => self::NAME,
                 'pageTitle' => ucfirst(self::NAME),
-                self::NAME => $this->reflectionStorage->getTraitReflections()
+                self::NAME => $this->reflectionStorage->getTraitReflections(),
             ]
         );
     }

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -43,7 +43,7 @@ final class FileSystem
 
     public function copyDirectory(string $sourceDirectory, string $destinationDirectory): void
     {
-        FileSystem::ensureDirectoryExists($destinationDirectory);
+        self::ensureDirectoryExists($destinationDirectory);
 
         /** @var RecursiveDirectoryIterator $iterator */
         $fileInfos = Finder::findFiles('*')->from($sourceDirectory)

--- a/tests/AbstractParserAwareTestCase.php
+++ b/tests/AbstractParserAwareTestCase.php
@@ -41,7 +41,7 @@ abstract class AbstractParserAwareTestCase extends TestCase
         $configuration = $this->container->get(Configuration::class);
         $configuration->resolveOptions([
             SourceOption::NAME => [__DIR__],
-            DestinationOption::NAME => TEMP_DIR
+            DestinationOption::NAME => TEMP_DIR,
         ]);
 
         $this->parser = $this->container->get(Parser::class);

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -30,7 +30,7 @@ final class ConfigurationTest extends AbstractContainerAwareTestCase
     {
         $options = $this->configuration->resolveOptions([
             SourceOption::NAME => [],
-            DestinationOption::NAME => TEMP_DIR
+            DestinationOption::NAME => TEMP_DIR,
         ]);
 
         $this->assertCount(8, $options);
@@ -57,7 +57,7 @@ final class ConfigurationTest extends AbstractContainerAwareTestCase
     {
         $configAndDestinationOptions = [
             DestinationOption::NAME => TEMP_DIR . '/api',
-            SourceOption::NAME => [__DIR__]
+            SourceOption::NAME => [__DIR__],
         ];
 
         $options = $this->configuration->resolveOptions($configAndDestinationOptions);

--- a/tests/Console/Command/GenerateCommandExecuteTest.php
+++ b/tests/Console/Command/GenerateCommandExecuteTest.php
@@ -33,7 +33,7 @@ final class GenerateCommandExecuteTest extends AbstractContainerAwareTestCase
 
         $input = new ArrayInput([
             SourceOption::NAME => [__DIR__ . '/Source'],
-            '--' . DestinationOption::NAME => TEMP_DIR . '/Api'
+            '--' . DestinationOption::NAME => TEMP_DIR . '/Api',
         ]);
 
         $exitCode = $this->generateCommand->run($input, new NullOutput);

--- a/tests/Console/Helper/ProgressBarTest.php
+++ b/tests/Console/Helper/ProgressBarTest.php
@@ -17,7 +17,7 @@ final class ProgressBarTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->progressBar = new ProgressBar(new NullOutput());
+        $this->progressBar = new ProgressBar(new NullOutput);
     }
 
     public function testInit(): void
@@ -40,7 +40,7 @@ final class ProgressBarTest extends TestCase
         $this->progressBar->increment(20);
 
         /** @var SymfonyProgressBar $bar */
-        $bar =  Assert::readAttribute($this->progressBar, 'bar');
+        $bar = Assert::readAttribute($this->progressBar, 'bar');
         $this->assertSame(20, $bar->getProgress());
 
         $this->progressBar->increment(30);

--- a/tests/Console/Progress/Source/SomeFunction.php
+++ b/tests/Console/Progress/Source/SomeFunction.php
@@ -2,6 +2,6 @@
 
 namespace EmptyNamespace\MyNamespace;
 
-function SomeFunction(): void
+function someFunction(): void
 {
 }

--- a/tests/Console/Progress/StepCounterTest.php
+++ b/tests/Console/Progress/StepCounterTest.php
@@ -17,7 +17,7 @@ final class StepCounterTest extends AbstractParserAwareTestCase
         $stepCounter = new StepCounter(
             $this->reflectionStorage,
             $namespaceReflectionCollector,
-            new ParentEmptyNamespacesResolver()
+            new ParentEmptyNamespacesResolver
         );
 
         $count = 2;    // index.html + elementlist.js

--- a/tests/DependencyInjection/Container/ContainerFactoryTest.php
+++ b/tests/DependencyInjection/Container/ContainerFactoryTest.php
@@ -16,7 +16,7 @@ final class ContainerFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->container = (new ContainerFactory())->create();
+        $this->container = (new ContainerFactory)->create();
     }
 
     public function test(): void

--- a/tests/Generator/AnnotationGroupsGeneratorTest.php
+++ b/tests/Generator/AnnotationGroupsGeneratorTest.php
@@ -23,7 +23,7 @@ final class AnnotationGroupsGeneratorTest extends AbstractContainerAwareTestCase
         $configuration->resolveOptions([
             'source' => [TEMP_DIR],
             'destination' => TEMP_DIR,
-            'annotationGroups' => ['deprecated']
+            'annotationGroups' => ['deprecated'],
         ]);
 
         /** @var Parser $parser */

--- a/tests/Generator/ExtendingSources/ExtendingClass.php
+++ b/tests/Generator/ExtendingSources/ExtendingClass.php
@@ -2,8 +2,8 @@
 
 namespace ApiGen\Tests\Generator\ExtendingSources;
 
-use ApiGen\Tests\Generator\NotLoadedSources;
+use ApiGen\Tests\Generator\NotLoadedSources\SomeClass;
 
-class ExtendingClass extends NotLoadedSources\SomeClass
+class ExtendingClass extends SomeClass
 {
 }

--- a/tests/Generator/Source/SomeClass.php
+++ b/tests/Generator/Source/SomeClass.php
@@ -4,17 +4,30 @@ namespace ApiGen\Tests\Generator\Source;
 
 class SomeClass
 {
+    /**
+     * @var int
+     */
     const SOME_CONST = 1;
 
+    /**
+     * @var int
+     */
     public const PUBLIC_CONST = 2;
 
     /**
      * @deprecated
+     * @var int
      */
     public const DEPRECATED_CONST = 5;
 
+    /**
+     * @var int
+     */
     protected const PROTECTED_CONST = 3;
 
+    /**
+     * @var int
+     */
     private const PRIVATE_CONST = 4;
 
     /**

--- a/tests/Generator/Source/SomeClass.php
+++ b/tests/Generator/Source/SomeClass.php
@@ -8,14 +8,14 @@ class SomeClass
 
     public const PUBLIC_CONST = 2;
 
-    protected const PROTECTED_CONST = 3;
-
-    private const PRIVATE_CONST = 4;
-
     /**
      * @deprecated
      */
     public const DEPRECATED_CONST = 5;
+
+    protected const PROTECTED_CONST = 3;
+
+    private const PRIVATE_CONST = 4;
 
     /**
      * @var string
@@ -31,7 +31,7 @@ class SomeClass
      * @var int
      */
     public $integerProperty = 11;
-    
+
     /**
      * Do not add param annotations here!
      */

--- a/tests/Utils/DefaultValueDumperTest.php
+++ b/tests/Utils/DefaultValueDumperTest.php
@@ -38,7 +38,7 @@ final class DefaultValueDumperTest extends TestCase
             [['cat', 'dog'], "array (\n" .
                 "  0 => 'cat',\n" .
                 "  1 => 'dog',\n" .
-                ')']
+                ')', ],
         ];
     }
 }

--- a/tests/Utils/FileSystemCopyTest.php
+++ b/tests/Utils/FileSystemCopyTest.php
@@ -15,6 +15,6 @@ final class FileSystemCopyTest extends TestCase
             TEMP_DIR . DIRECTORY_SEPARATOR . 'NewDir'
         );
 
-        $this->assertFileExists(TEMP_DIR . DIRECTORY_SEPARATOR .  'NewDir');
+        $this->assertFileExists(TEMP_DIR . DIRECTORY_SEPARATOR . 'NewDir');
     }
 }

--- a/tests/Utils/RelativePathResolverTest.php
+++ b/tests/Utils/RelativePathResolverTest.php
@@ -31,12 +31,12 @@ final class RelativePathResolverTest extends AbstractContainerAwareTestCase
     {
         $this->configuration->resolveOptions([
             DestinationOption::NAME => TEMP_DIR,
-            SourceOption::NAME => [TEMP_DIR]
+            SourceOption::NAME => [TEMP_DIR],
         ]);
 
         $this->assertSame('some-file.txt', $this->relativePathResolver->getRelativePath(TEMP_DIR . '/some-file.txt'));
 
-        $testPath = 'some' .DIRECTORY_SEPARATOR. 'dir' .DIRECTORY_SEPARATOR. 'file.txt';
+        $testPath = 'some' . DIRECTORY_SEPARATOR . 'dir' . DIRECTORY_SEPARATOR . 'file.txt';
         $this->assertSame(
             $testPath,
             $this->relativePathResolver->getRelativePath(TEMP_DIR . DIRECTORY_SEPARATOR . $testPath)
@@ -47,7 +47,7 @@ final class RelativePathResolverTest extends AbstractContainerAwareTestCase
     {
         $this->configuration->resolveOptions([
             DestinationOption::NAME => TEMP_DIR,
-            SourceOption::NAME => [TEMP_DIR]
+            SourceOption::NAME => [TEMP_DIR],
         ]);
 
         $this->expectException(InvalidArgumentException::class);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,6 +5,6 @@ include __DIR__ . '/../vendor/autoload.php';
 define('TEMP_DIR', sys_get_temp_dir() . '/_apigen_cache');
 ApiGen\Utils\FileSystem::ensureDirectoryExists(TEMP_DIR);
 
-register_shutdown_function(function () {
+register_shutdown_function(function (): void {
     Nette\Utils\FileSystem::delete(TEMP_DIR);
 });


### PR DESCRIPTION
Use [prepared configs](https://www.tomasvotruba.cz/blog/2017/08/07/7-new-features-in-easy-coding-standard-22/#2-prepared-configs) from ECS 2.2

This will be last bigger change for a long time.

### Changes 

- applied [Symfony checkers set](https://github.com/Symplify/EasyCodingStandard/blob/master/config/symfony-checkers.neon), apart few doc style rules
- added dot space checkers, `' . '` - 1 from each side
- last item in array has to end with comma `,`
- there is space after `! `, e.g. `if (! $autoloader)`
- partial uses [disabled](https://github.com/ApiGen/ApiGen/pull/977/files#diff-db71ac2c5cb10a341e624322fac72c1eR19), to make 1 way to import namespaces 


### Related

- disabled `SomeTrait`, it caused tests to fail: https://github.com/ApiGen/ApiGen/pull/977/files#diff-639c1b69f36cde9fa148db8015ee37e2
- fixed `getStartLine()` and `getEndLine()` in trait: https://github.com/ApiGen/ApiGen/pull/977/files#diff-8cf7e7f19d71a71b48d468ecce6d7826


@vlastavesely It would be great to remove or resolve all @todos, so they don't [polute config](https://github.com/ApiGen/ApiGen/pull/977/files#diff-db71ac2c5cb10a341e624322fac72c1eR88). This [might grow and cause everything](https://blog.codinghorror.com/the-broken-window-theory/) to be @todo and unfinished