### PR TITLE
fixed Recoverable fatal error

### DIFF
--- a/packages/ThemeDefault/src/class.latte
+++ b/packages/ThemeDefault/src/class.latte
@@ -166,8 +166,7 @@
                 <tr>
                     <td>
                         {foreach $parentClass->getOwnProperties() as $parentClassProperty}
-                            <code>{block|trim}
-                                <a href="{$parentClassProperty|linkReflection}" n:class="$parentClassProperty->isDeprecated() ? deprecated, property-name">${$parentClassProperty->getName()}</a>{/block}</code>{sep}, {/sep}
+                            <code><a href="{$parentClassProperty|linkReflection}" n:class="$parentClassProperty->isDeprecated() ? deprecated, property-name">${$parentClassProperty->getName()}</a></code>{sep}, {/sep}
                         {/foreach}
                     </td>
                 </tr>


### PR DESCRIPTION
Generating API for our company's system succeeded with one problem only. I am not really sure what class caused it but it was leading me to `trim` filter and after I removed it from `class.latte`, problem is gone. Strange is that it points to the project's dependencies and not ApiGen's:

```
Recoverable fatal error:  Object of class Latte\Runtime\FilterInfo could not be converted to string in /var/www/ivicom.cs/vendor/latte/latte/src/Latte/Runtime/Filters.php on line 600
```

What surprises me a bit is that API for Doctrine entities is generated without a fail. @TomasVotruba have you made any changes that could fix it somehow?

------

But still, ApiGen is really slow - it took one hour to generate complete API (233 entries).