### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.1",
         "roave/better-reflection": "dev-master#a402048",
-        "phpdocumentor/reflection-docblock": "^3.1",
+        "phpdocumentor/reflection-docblock": "^4.1",
         "kukulich/fshl": "^2.1",
 
         "latte/latte": "^2.4",


### PR DESCRIPTION
Using reflection-docblock at `^3.1` conflicts with better-reflection, which uses `^4.1`.

It would be appreciated if someone else could test this. I got a couple test failures from the `RelativePathResolver`, but a) I don't think those are related, and b) there are some symlinks (which I can't change) that I think are causing the failures.