### PR TITLE
Fixes in @see annotations, added tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "bin": ["bin/apigen"],
     "require": {
         "php": "^7.1",
-        "roave/better-reflection": "dev-master#a402048",
+        "roave/better-reflection": "dev-master#d32bda4",
         "kukulich/fshl": "^2.1",
 
         "latte/latte": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "bin": ["bin/apigen"],
     "require": {
         "php": "^7.1",
-        "roave/better-reflection": "dev-master#d32bda4",
+        "roave/better-reflection": "dev-master#c87d856",
         "kukulich/fshl": "^2.1",
 
         "latte/latte": "^2.4",
@@ -33,7 +33,7 @@
         "tracy/tracy": "^2.4",
         "phpunit/phpunit": "^6.0",
         "phpstan/phpstan": "^0.8",
-        "symplify/easy-coding-standard": "^2.2"
+        "symplify/easy-coding-standard": "2.3.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
             "packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/Source/functionWithConstant.php",
             "packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/Source/functionWithVariadic.php",
             "packages/Reflection/tests/Reflection/Function_/FunctionParameterReflection/Source/functionWithClass.php",
-            "packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/SomeClassWithSeeAnnotations.php"
+            "packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/SomeClassWithSeeAnnotations.php",
+            "packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/SomeFunction.php"
         ]
     },
     "scripts": {

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -32,6 +32,7 @@ parameters:
         - PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer
         - PhpCsFixer\Fixer\Operator\NewWithBracesFixer
         - PhpCsFixer\Fixer\Phpdoc\PhpdocInlineTagFixer
+        - PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer
         # resolve later
         - Symplify\CodingStandard\Sniffs\DependencyInjection\NoClassInstantiationSniff
 

--- a/packages/Annotation/src/FqsenResolver/ElementResolver.php
+++ b/packages/Annotation/src/FqsenResolver/ElementResolver.php
@@ -3,10 +3,13 @@
 namespace ApiGen\Annotation\FqsenResolver;
 
 use ApiGen\Reflection\Contract\Reflection\AbstractReflectionInterface;
+use ApiGen\Reflection\Contract\Reflection\Class_\AbstractClassElementInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassMethodReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassPropertyReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
+use ApiGen\Reflection\Contract\Reflection\Interface_\AbstractInterfaceElementInterface;
 use ApiGen\Reflection\Contract\Reflection\Function_\FunctionReflectionInterface;
+use ApiGen\Reflection\Contract\Reflection\Trait_\AbstractTraitElementInterface;
 use ApiGen\Reflection\ReflectionStorage;
 use Nette\Utils\Strings;
 use phpDocumentor\Reflection\FqsenResolver;
@@ -73,7 +76,7 @@ final class ElementResolver
         }
 
         if ($isFunction) {
-            $namespace = $reflection->getDeclaringClass()->getNamespaceName();
+            $namespace = $this->getNamespace($reflection);
             $functionReflections = $this->reflectionStorage->getFunctionReflections();
 
             $namespacedFunctionName = $namespace . '\\' . $functionName;
@@ -105,5 +108,18 @@ final class ElementResolver
         }
 
         return $classReflection;
+    }
+
+    private function getNamespace(AbstractReflectionInterface $reflection): string
+    {
+        if ($reflection instanceof AbstractClassElementInterface) {
+            return $reflection->getDeclaringClass()->getNamespaceName();
+        } elseif ($reflection instanceof AbstractInterfaceElementInterface) {
+            return $reflection->getDeclaringInterface()->getNamespaceName();
+        } elseif ($reflection instanceof AbstractTraitElementInterface) {
+            return $reflection->getDeclaringTrait()->getNamespaceName();
+        } else {
+            return $reflection->getNamespaceName();
+        }
     }
 }

--- a/packages/Annotation/src/FqsenResolver/ElementResolver.php
+++ b/packages/Annotation/src/FqsenResolver/ElementResolver.php
@@ -7,8 +7,8 @@ use ApiGen\Reflection\Contract\Reflection\Class_\AbstractClassElementInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassMethodReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassPropertyReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
-use ApiGen\Reflection\Contract\Reflection\Interface_\AbstractInterfaceElementInterface;
 use ApiGen\Reflection\Contract\Reflection\Function_\FunctionReflectionInterface;
+use ApiGen\Reflection\Contract\Reflection\Interface_\AbstractInterfaceElementInterface;
 use ApiGen\Reflection\Contract\Reflection\Trait_\AbstractTraitElementInterface;
 use ApiGen\Reflection\ReflectionStorage;
 use Nette\Utils\Strings;
@@ -114,9 +114,9 @@ final class ElementResolver
             return $reflection->getDeclaringInterfaceName();
         } elseif ($reflection instanceof AbstractTraitElementInterface) {
             return $reflection->getDeclaringTraitName();
-        } else {
-            return $reflection->getName();
         }
+
+        return $reflection->getName();
     }
 
     private function getClassyReflection(string $name): ?AbstractReflectionInterface

--- a/packages/Annotation/src/FqsenResolver/ElementResolver.php
+++ b/packages/Annotation/src/FqsenResolver/ElementResolver.php
@@ -87,6 +87,7 @@ final class ElementResolver
         $classReflectionName = ltrim($classReflectionName, '\\');
 
         // @todo return only string on non resolved existing class
+        /** @var ClassReflectionInterface|InterfaceReflectionInterface|TraitReflectionInterface */
         $classyReflection = $this->getClassyReflection($classReflectionName);
 
         if ($classyReflection === null) {
@@ -111,7 +112,7 @@ final class ElementResolver
             return $reflection->getDeclaringClassName();
         } elseif ($reflection instanceof AbstractInterfaceElementInterface) {
             return $reflection->getDeclaringInterfaceName();
-        } elseif ($reflection instanceof AbstractInterfaceElementInterface) {
+        } elseif ($reflection instanceof AbstractTraitElementInterface) {
             return $reflection->getDeclaringTraitName();
         } else {
             return $reflection->getName();
@@ -133,7 +134,7 @@ final class ElementResolver
         return null;
     }
 
-    private function getNamespace(AbstractReflectionInterface $reflection): string
+    private function getNamespace(AbstractReflectionInterface $reflection): ?string
     {
         if ($reflection instanceof AbstractClassElementInterface) {
             return $reflection->getDeclaringClass()->getNamespaceName();
@@ -141,8 +142,10 @@ final class ElementResolver
             return $reflection->getDeclaringInterface()->getNamespaceName();
         } elseif ($reflection instanceof AbstractTraitElementInterface) {
             return $reflection->getDeclaringTrait()->getNamespaceName();
-        } else {
+        } elseif ($reflection instanceof FunctionReflectionInterface) {
             return $reflection->getNamespaceName();
         }
+
+        return null;
     }
 }

--- a/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/InterfaceWithSeeAnnotationsInterface.php
+++ b/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/InterfaceWithSeeAnnotationsInterface.php
@@ -2,11 +2,11 @@
 
 namespace ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource;
 
-use ApiGen\Annotation\Tests\AnnotationDecoratorSource\ReturnedClass;
-
-interface SomeInterfaceWithSeeAnnotations
+interface InterfaceWithSeeAnnotationsInterface
 {
     /**
+     * Test.
+     *
      * @see SomeClassWithSeeAnnotations::returnArray()
      */
     public function someSexyMethod(): int;

--- a/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/SomeFunction.php
+++ b/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/SomeFunction.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource;
+
+use ApiGen\Annotation\Tests\AnnotationDecoratorSource\ReturnedClass;
+
+function anotherFunction(): void
+{
+}
+
+/**
+ * @see anotherFunction()
+ */
+function someFunction(): void
+{
+}

--- a/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/SomeFunction.php
+++ b/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/SomeFunction.php
@@ -2,13 +2,13 @@
 
 namespace ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource;
 
-use ApiGen\Annotation\Tests\AnnotationDecoratorSource\ReturnedClass;
-
 function anotherFunction(): void
 {
 }
 
 /**
+ * Test.
+ *
  * @see anotherFunction()
  */
 function someFunction(): void

--- a/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/SomeInterfaceWithSeeAnnotations.php
+++ b/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberSource/SomeInterfaceWithSeeAnnotations.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource;
+
+use ApiGen\Annotation\Tests\AnnotationDecoratorSource\ReturnedClass;
+
+interface SomeInterfaceWithSeeAnnotations
+{
+    /**
+     * @see SomeClassWithSeeAnnotations::returnArray()
+     */
+    public function someSexyMethod(): int;
+}

--- a/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberTest.php
+++ b/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberTest.php
@@ -4,8 +4,8 @@ namespace ApiGen\Annotation\Tests\AnnotationSubscriber;
 
 use ApiGen\Annotation\AnnotationDecorator;
 use ApiGen\Annotation\AnnotationList;
+use ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource\InterfaceWithSeeAnnotationsInterface;
 use ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource\SomeClassWithSeeAnnotations;
-use ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource\SomeInterfaceWithSeeAnnotations;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassMethodReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Function_\FunctionReflectionInterface;
@@ -47,9 +47,11 @@ final class SeeAnnotationSubscriberTest extends AbstractParserAwareTestCase
         $this->classReflection = $this->reflectionStorage->getClassReflections()[SomeClassWithSeeAnnotations::class];
         $this->methodReflection = $this->classReflection->getMethod('returnArray');
         $this->functionReflection = $this->reflectionStorage->getFunctionReflections()[
-        	'ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource\someFunction'
+            'ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource\someFunction'
         ];
-        $this->interfaceReflection = $this->reflectionStorage->getInterfaceReflections()[SomeInterfaceWithSeeAnnotations::class];
+        $this->interfaceReflection = $this->reflectionStorage->getInterfaceReflections()[
+            InterfaceWithSeeAnnotationsInterface::class
+        ];
     }
 
     public function testPropertyOnMissingClassReflection(): void
@@ -111,8 +113,8 @@ final class SeeAnnotationSubscriberTest extends AbstractParserAwareTestCase
         $this->assertSame(
             '<code><a href="function-ApiGen.Annotation.Tests.AnnotationSubscriber.SeeAnnotationSubscriberSource'
             . '.anotherFunction.html">anotherFunction()</a></code>',
-            $this->annotationDecorator->decorate($seeFunctionAnnotation, $this->functionReflection
-        ));
+            $this->annotationDecorator->decorate($seeFunctionAnnotation, $this->functionReflection)
+        );
 
         $seeFunctionAnnotation = $this->methodReflection->getAnnotation(AnnotationList::SEE)[5];
 
@@ -125,12 +127,13 @@ final class SeeAnnotationSubscriberTest extends AbstractParserAwareTestCase
 
     public function testInterface(): void
     {
-        $seeMethodAnnotation = $this->interfaceReflection->getMethod('someSexyMethod')->getAnnotation(AnnotationList::SEE)[0];
+        $seeMethodAnnotation = $this->interfaceReflection->getMethod('someSexyMethod')
+            ->getAnnotation(AnnotationList::SEE)[0];
 
         $this->assertSame(
             '<code><a href="class-ApiGen.Annotation.Tests.AnnotationSubscriber.SeeAnnotationSubscriberSource'
             . '.SomeClassWithSeeAnnotations.html#_returnArray">SomeClassWithSeeAnnotations::returnArray()</a></code>',
-            $this->annotationDecorator->decorate($seeMethodAnnotation, $this->interfaceReflection
-        ));
+            $this->annotationDecorator->decorate($seeMethodAnnotation, $this->interfaceReflection)
+        );
     }
 }

--- a/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberTest.php
+++ b/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberTest.php
@@ -5,9 +5,11 @@ namespace ApiGen\Annotation\Tests\AnnotationSubscriber;
 use ApiGen\Annotation\AnnotationDecorator;
 use ApiGen\Annotation\AnnotationList;
 use ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource\SomeClassWithSeeAnnotations;
+use ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource\SomeInterfaceWithSeeAnnotations;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassMethodReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Function_\FunctionReflectionInterface;
+use ApiGen\Reflection\Contract\Reflection\Interface_\InterfaceReflectionInterface;
 use ApiGen\Tests\AbstractParserAwareTestCase;
 
 final class SeeAnnotationSubscriberTest extends AbstractParserAwareTestCase
@@ -32,6 +34,11 @@ final class SeeAnnotationSubscriberTest extends AbstractParserAwareTestCase
      */
     private $functionReflection;
 
+    /**
+     * @var InterfaceReflectionInterface
+     */
+    private $interfaceReflection;
+
     protected function setUp(): void
     {
         $this->parser->parseFilesAndDirectories([__DIR__ . '/SeeAnnotationSubscriberSource']);
@@ -42,6 +49,7 @@ final class SeeAnnotationSubscriberTest extends AbstractParserAwareTestCase
         $this->functionReflection = $this->reflectionStorage->getFunctionReflections()[
         	'ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource\someFunction'
         ];
+        $this->interfaceReflection = $this->reflectionStorage->getInterfaceReflections()[SomeInterfaceWithSeeAnnotations::class];
     }
 
     public function testPropertyOnMissingClassReflection(): void
@@ -113,5 +121,16 @@ final class SeeAnnotationSubscriberTest extends AbstractParserAwareTestCase
             . '.someExistingFunction.html">someExistingFunction()</a></code>',
             $this->annotationDecorator->decorate($seeFunctionAnnotation, $this->methodReflection)
         );
+    }
+
+    public function testInterface(): void
+    {
+        $seeMethodAnnotation = $this->interfaceReflection->getMethod('someSexyMethod')->getAnnotation(AnnotationList::SEE)[0];
+
+        $this->assertSame(
+            '<code><a href="class-ApiGen.Annotation.Tests.AnnotationSubscriber.SeeAnnotationSubscriberSource'
+            . '.SomeClassWithSeeAnnotations.html#_returnArray">SomeClassWithSeeAnnotations::returnArray()</a></code>',
+            $this->annotationDecorator->decorate($seeMethodAnnotation, $this->interfaceReflection
+        ));
     }
 }

--- a/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberTest.php
+++ b/packages/Annotation/tests/AnnotationSubscriber/SeeAnnotationSubscriberTest.php
@@ -7,6 +7,7 @@ use ApiGen\Annotation\AnnotationList;
 use ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource\SomeClassWithSeeAnnotations;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassMethodReflectionInterface;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
+use ApiGen\Reflection\Contract\Reflection\Function_\FunctionReflectionInterface;
 use ApiGen\Tests\AbstractParserAwareTestCase;
 
 final class SeeAnnotationSubscriberTest extends AbstractParserAwareTestCase
@@ -26,6 +27,11 @@ final class SeeAnnotationSubscriberTest extends AbstractParserAwareTestCase
      */
     private $methodReflection;
 
+    /**
+     * @var FunctionReflectionInterface
+     */
+    private $functionReflection;
+
     protected function setUp(): void
     {
         $this->parser->parseFilesAndDirectories([__DIR__ . '/SeeAnnotationSubscriberSource']);
@@ -33,6 +39,9 @@ final class SeeAnnotationSubscriberTest extends AbstractParserAwareTestCase
 
         $this->classReflection = $this->reflectionStorage->getClassReflections()[SomeClassWithSeeAnnotations::class];
         $this->methodReflection = $this->classReflection->getMethod('returnArray');
+        $this->functionReflection = $this->reflectionStorage->getFunctionReflections()[
+        	'ApiGen\Annotation\Tests\AnnotationSubscriber\SeeAnnotationSubscriberSource\someFunction'
+        ];
     }
 
     public function testPropertyOnMissingClassReflection(): void
@@ -89,6 +98,14 @@ final class SeeAnnotationSubscriberTest extends AbstractParserAwareTestCase
 
     public function testFunction(): void
     {
+        $seeFunctionAnnotation = $this->functionReflection->getAnnotation(AnnotationList::SEE)[0];
+
+        $this->assertSame(
+            '<code><a href="function-ApiGen.Annotation.Tests.AnnotationSubscriber.SeeAnnotationSubscriberSource'
+            . '.anotherFunction.html">anotherFunction()</a></code>',
+            $this->annotationDecorator->decorate($seeFunctionAnnotation, $this->functionReflection
+        ));
+
         $seeFunctionAnnotation = $this->methodReflection->getAnnotation(AnnotationList::SEE)[5];
 
         $this->assertSame(

--- a/packages/BetterReflection/src/SourceLocator/ProjectVendorSourceLocatorFactory.php
+++ b/packages/BetterReflection/src/SourceLocator/ProjectVendorSourceLocatorFactory.php
@@ -2,6 +2,7 @@
 
 namespace ApiGen\BetterReflection\SourceLocator;
 
+use Roave\BetterReflection\SourceLocator\Ast\Locator as AstLocator;
 use Roave\BetterReflection\SourceLocator\Type\AggregateSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\ComposerSourceLocator;
 use Roave\BetterReflection\SourceLocator\Type\SourceLocator;
@@ -18,6 +19,16 @@ final class ProjectVendorSourceLocatorFactory
      * @var string
      */
     private const STANDARD_AUTOLOAD_LOCATION = '/vendor/autoload.php';
+
+    /**
+     * @var AstLocator
+     */
+    private $astLocator;
+
+    public function __construct(AstLocator $astLocator)
+    {
+        $this->astLocator = $astLocator;
+    }
 
     /**
      * @param string[] $directories
@@ -58,6 +69,6 @@ final class ProjectVendorSourceLocatorFactory
      */
     private function createComposerSourceLocator(string $autoloadPath): ComposerSourceLocator
     {
-        return new ComposerSourceLocator(include $autoloadPath);
+        return new ComposerSourceLocator(include $autoloadPath, $this->astLocator);
     }
 }

--- a/packages/BetterReflection/src/config/services.yml
+++ b/packages/BetterReflection/src/config/services.yml
@@ -7,8 +7,7 @@ services:
 
     # cached AST Locator
     Roave\BetterReflection\SourceLocator\Ast\PhpParserLocator: ~
-    Roave\BetterReflection\SourceLocator\Ast\Locator:
-        alias: Roave\BetterReflection\SourceLocator\Ast\PhpParserLocator
+    Roave\BetterReflection\SourceLocator\Ast\Locator: ~
 
     # nikic\PHP-Parser
     PhpParser\Parser:

--- a/packages/Reflection/src/Parser/Parser.php
+++ b/packages/Reflection/src/Parser/Parser.php
@@ -193,7 +193,7 @@ final class Parser
 
     private function parseFunctions(SourceLocator $sourceLocator): void
     {
-        $functionReflector = new FunctionReflector($sourceLocator);
+        $functionReflector = new FunctionReflector($sourceLocator, new ClassReflector($sourceLocator));
         $functionReflections = $this->transformBetterFunctionReflections($functionReflector);
         $this->reflectionStorage->setFunctionReflections($functionReflections);
     }

--- a/packages/Reflection/src/Reflection/AbstractParameterReflection.php
+++ b/packages/Reflection/src/Reflection/AbstractParameterReflection.php
@@ -33,7 +33,7 @@ abstract class AbstractParameterReflection implements AbstractParameterReflectio
 
     public function getTypeHint(): string
     {
-        $types = (string) $this->betterParameterReflection->getTypeHint();
+        $types = (string) $this->betterParameterReflection->getType();
         $types = $this->removeClassPreSlashes($types);
         if ($types) {
             return $types;

--- a/packages/Reflection/tests/Parser/ObjectClassTest.php
+++ b/packages/Reflection/tests/Parser/ObjectClassTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Reflection\Tests\Parser;
+
+use ApiGen\Reflection\Parser\Parser;
+use ApiGen\Reflection\ReflectionStorage;
+use ApiGen\Reflection\Tests\Parser\Source\Object;
+use ApiGen\Tests\AbstractContainerAwareTestCase;
+
+final class ObjectClassTest extends AbstractContainerAwareTestCase
+{
+    public function test(): void
+    {
+        /** @var Parser $parser */
+        $parser = $this->container->get(Parser::class);
+        $parser->parseFilesAndDirectories([__DIR__ . '/Source']);
+
+        /** @var ReflectionStorage */
+        $reflectionStorage = $this->container->get(ReflectionStorage::class);
+
+        $classReflections = $reflectionStorage->getClassReflections();
+        $this->assertCount(3, $classReflections);
+
+        $this->assertArrayHasKey(Object::class, $classReflections);
+        $this->assertSame(Object::class, $classReflections[Object::class]->getName());
+    }
+}

--- a/packages/Reflection/tests/Parser/ObjectClassTest.php
+++ b/packages/Reflection/tests/Parser/ObjectClassTest.php
@@ -4,24 +4,44 @@ namespace ApiGen\Reflection\Tests\Parser;
 
 use ApiGen\Reflection\Parser\Parser;
 use ApiGen\Reflection\ReflectionStorage;
+use ApiGen\Reflection\Tests\Parser\Source\ChildOfObject;
 use ApiGen\Reflection\Tests\Parser\Source\Object;
 use ApiGen\Tests\AbstractContainerAwareTestCase;
 
 final class ObjectClassTest extends AbstractContainerAwareTestCase
 {
-    public function test(): void
+    /**
+     * @var Parser
+     */
+    private $parser;
+
+    /**
+     * @var ReflectionStorage
+     */
+    private $reflectionStorage;
+
+    public function setUp(): void
     {
-        /** @var Parser $parser */
-        $parser = $this->container->get(Parser::class);
-        $parser->parseFilesAndDirectories([__DIR__ . '/Source']);
+        $this->parser = $this->container->get(Parser::class);
+        $this->parser->parseFilesAndDirectories([__DIR__ . '/Source']);
 
-        /** @var ReflectionStorage */
-        $reflectionStorage = $this->container->get(ReflectionStorage::class);
+        $this->reflectionStorage = $this->container->get(ReflectionStorage::class);
+    }
 
-        $classReflections = $reflectionStorage->getClassReflections();
-        $this->assertCount(3, $classReflections);
+    public function testDirect(): void
+    {
+        $classReflections = $this->reflectionStorage->getClassReflections();
+        $this->assertCount(4, $classReflections);
 
         $this->assertArrayHasKey(Object::class, $classReflections);
         $this->assertSame(Object::class, $classReflections[Object::class]->getName());
+    }
+
+    public function testGetParent(): void
+    {
+        $classReflections = $this->reflectionStorage->getClassReflections();
+
+        $classReflection = $classReflections[ChildOfObject::class]->getParentClass();
+        $this->assertSame(Object::class, $classReflection->getName());
     }
 }

--- a/packages/Reflection/tests/Parser/ParseClassWithParentFromAnotherSourceTest.php
+++ b/packages/Reflection/tests/Parser/ParseClassWithParentFromAnotherSourceTest.php
@@ -14,7 +14,7 @@ final class ParseClassWithParentFromAnotherSourceTest extends AbstractParserAwar
         $this->parser->parseFilesAndDirectories([__DIR__ . '/Source']);
 
         $classReflections = $this->reflectionStorage->getClassReflections();
-        $this->assertCount(2, $classReflections);
+        $this->assertCount(3, $classReflections);
 
         $classReflection = $classReflections[ClassWithParentFromAnotherSource::class];
 

--- a/packages/Reflection/tests/Parser/ParseClassWithParentFromAnotherSourceTest.php
+++ b/packages/Reflection/tests/Parser/ParseClassWithParentFromAnotherSourceTest.php
@@ -14,7 +14,7 @@ final class ParseClassWithParentFromAnotherSourceTest extends AbstractParserAwar
         $this->parser->parseFilesAndDirectories([__DIR__ . '/Source']);
 
         $classReflections = $this->reflectionStorage->getClassReflections();
-        $this->assertCount(3, $classReflections);
+        $this->assertCount(4, $classReflections);
 
         $classReflection = $classReflections[ClassWithParentFromAnotherSource::class];
 

--- a/packages/Reflection/tests/Parser/Source/ChildOfObject.php
+++ b/packages/Reflection/tests/Parser/Source/ChildOfObject.php
@@ -2,6 +2,6 @@
 
 namespace ApiGen\Reflection\Tests\Parser\Source;
 
-class Object
+final class ChildOfObject extends Object
 {
 }

--- a/packages/Reflection/tests/Parser/Source/Object.php
+++ b/packages/Reflection/tests/Parser/Source/Object.php
@@ -2,8 +2,6 @@
 
 namespace ApiGen\Reflection\Tests\Parser\Source;
 
-use ApiGen\Reflection\Tests\Parser\AnotherSource\ParentClassFromAnotherSource;
-
 final class Object
 {
 }

--- a/packages/Reflection/tests/Parser/Source/Object.php
+++ b/packages/Reflection/tests/Parser/Source/Object.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace ApiGen\Reflection\Tests\Parser\Source;
+
+use ApiGen\Reflection\Tests\Parser\AnotherSource\ParentClassFromAnotherSource;
+
+final class Object
+{
+}


### PR DESCRIPTION
I tried to locate source of problems from #935 but I found a few other problems with **see** annotation.

Currently I am stuck on problem that @dg had too here: 985. It is about the class named `Object`. I tested it and problem is not in directloading but in parent resolving. `BetterReflection` uses this: https://github.com/phpDocumentor/TypeResolver/blob/master/src/TypeResolver.php for resolving parent classes and thus `object` is resolved as PHP 7.2 typehint and not a class name.

For the moment, I do not know what solution would be the best? Any ideas?