### PR TITLE
Replace camelcase option names

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Associated element is internal, so ApiGen hides it.
 
 ## Themes
 
-To enable a custom theme just provide `themeDirectory` configuration option in your `apigen.yml`:
+To enable a custom theme just provide `theme_directory` configuration option in your `apigen.yml`:
 
 ```yaml
 parameters:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Just look at [**ApiGen API**](https://apigen.github.io/ApiGen):
 
 ![ApiGen Preview](docs/preview.png)
 
-## Your Help is Needed to Finish 5.x Release  
+## Your Help is Needed to Finish 5.x Release
 
 :heart: We need your help to test new version of ApiGen.
 
@@ -78,10 +78,10 @@ the root of your project:
 
 ```yaml
 parameters:
-    visibilityLevels: [public, protected] # array
-    annotationGroups: [todo, deprecated] # array
+    visibility_levels: [public, protected] # array
+    annotation_groups: [todo, deprecated] # array
     title: "ApiGen Docs" # string
-    baseUrl: "http://apigen.org/api" # string
+    base_url: "http://apigen.org/api" # string
     overwrite: false # bool
 ```
 
@@ -121,7 +121,7 @@ A website url.
 ```php
 /**
  * This is already mentioned on Wiki.
- * @link https://en.wikipedia.org/wiki/United_we_stand,_divided_we_fall Click to see a cool quote  
+ * @link https://en.wikipedia.org/wiki/United_we_stand,_divided_we_fall Click to see a cool quote
  */
 ```
 
@@ -129,10 +129,10 @@ A website url.
 
 ```html
 This is already mentioned on Wiki.
-@link <a href="https://en.wikipedia.org/wiki/United_we_stand,_divided_we_fall">Click to see a cool quote</a> 
+@link <a href="https://en.wikipedia.org/wiki/United_we_stand,_divided_we_fall">Click to see a cool quote</a>
 ```
 
-### `@internal` 
+### `@internal`
 
 Associated element is internal, so ApiGen hides it.
 
@@ -143,7 +143,7 @@ To enable a custom theme just provide `themeDirectory` configuration option in y
 
 ```yaml
 parameters:
-    themeDirectory: path/to/theme # path to theme's config file
+    theme_directory: path/to/theme # path to theme's config file
 ```
 
 ## Contributing

--- a/packages/ModularConfiguration/src/Option/AnnotationGroupsOption.php
+++ b/packages/ModularConfiguration/src/Option/AnnotationGroupsOption.php
@@ -9,7 +9,7 @@ final class AnnotationGroupsOption implements OptionInterface
     /**
      * @var string
      */
-    public const NAME = 'annotationGroups';
+    public const NAME = 'annotation_groups';
 
     public function getName(): string
     {

--- a/packages/ModularConfiguration/src/Option/BaseUrlOption.php
+++ b/packages/ModularConfiguration/src/Option/BaseUrlOption.php
@@ -9,7 +9,7 @@ final class BaseUrlOption implements OptionInterface
     /**
      * @var string
      */
-    public const NAME = 'baseUrl';
+    public const NAME = 'base_url';
 
     public function getName(): string
     {

--- a/packages/ModularConfiguration/src/Option/ThemeDirectoryOption.php
+++ b/packages/ModularConfiguration/src/Option/ThemeDirectoryOption.php
@@ -11,7 +11,7 @@ final class ThemeDirectoryOption implements OptionInterface
     /**
      * @var string
      */
-    public const NAME = 'themeDirectory';
+    public const NAME = 'theme_directory';
 
     /**
      * @var FileSystem

--- a/packages/ModularConfiguration/src/Option/VisibilityLevelOption.php
+++ b/packages/ModularConfiguration/src/Option/VisibilityLevelOption.php
@@ -10,7 +10,7 @@ final class VisibilityLevelOption implements OptionInterface
     /**
      * @var string
      */
-    public const NAME = 'visibilityLevels';
+    public const NAME = 'visibility_levels';
 
     /**
      * @var string

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -49,16 +49,6 @@ final class Configuration
 
         $resolvedOptions = $this->configurationResolver->resolveValuesWithDefaults($options);
 
-        // hack to remove duplicated lowercased value
-        unset($resolvedOptions[strtolower(VisibilityLevelOption::NAME)]);
-
-        $baseUrlKeyLowered = strtolower(BaseUrlOption::NAME);
-        if (isset($resolvedOptions[$baseUrlKeyLowered])) {
-            $resolvedOptions[BaseUrlOption::NAME] = $resolvedOptions[$baseUrlKeyLowered];
-        }
-
-        unset($resolvedOptions[$baseUrlKeyLowered]);
-
         return $this->options = $resolvedOptions;
     }
 


### PR DESCRIPTION
Use underscores instead of camelcase to fix problems caused by the fact that Yaml is case insensitive.

Closes #1025 and #1007 