### PR TITLE
use newer symfony to fix bug in parsing apigen.yml

### DIFF
--- a/apigen.yml
+++ b/apigen.yml
@@ -2,3 +2,4 @@ parameters:
     title: "ApiGen It-self"
     visibilityLevels: [public, protected]
     baseUrl: http://apigen.org
+    themeDirectory: tests/testThemeDir/src

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "apigen/apigen",
     "description": "PHP 7.1 source code API generator.",
     "license": "MIT",
+    "minimum-stability": "dev",
     "authors": [
         { "name": "ApiGen Contributors", "homepage": "https://github.com/apigen/apigen/graphs/contributors" },
         { "name": "Jaroslav Hanslík", "homepage": "https://github.com/kukulich" },
@@ -19,12 +20,12 @@
         "nette/finder": "^2.4",
         "nette/neon": "^2.4",
 
-        "symfony/config": "^3.3",
-        "symfony/console": "^3.3",
-        "symfony/finder": "^3.3",
-        "symfony/dependency-injection": "^3.3",
-        "symfony/http-kernel": "^3.3",
-        "symfony/yaml": "^3.3",
+        "symfony/config": "^3.4",
+        "symfony/console": "^3.4",
+        "symfony/finder": "^3.4",
+        "symfony/dependency-injection": "^3.4",
+        "symfony/http-kernel": "^3.4",
+        "symfony/yaml": "^3.4",
         "symplify/package-builder": "^2.2",
         "psr/container": "^1.0",
         "zendframework/zend-code": "^3.1"

--- a/tests/Configuration/ConfigurationTest.php
+++ b/tests/Configuration/ConfigurationTest.php
@@ -34,17 +34,18 @@ final class ConfigurationTest extends AbstractContainerAwareTestCase
         ]);
 
         $this->assertCount(8, $options);
-
-        $this->assertSame([
-            TitleOption::NAME => 'ApiGen It-self',
-            SourceOption::NAME => [],
-            DestinationOption::NAME => TEMP_DIR,
+    $intendedOptions = [
             AnnotationGroupsOption::NAME => [],
             BaseUrlOption::NAME => 'http://apigen.org',
+            DestinationOption::NAME => TEMP_DIR,
             OverwriteOption::NAME => false,
+            SourceOption::NAME => [],
             ThemeDirectoryOption::NAME => realpath(__DIR__ . '/../../packages/ThemeDefault/src'),
+            TitleOption::NAME => 'ApiGen It-self',
             VisibilityLevelOption::NAME => 768,
-        ], $options);
+        ];
+    ksort($options);
+        $this->assertSame($intendedOptions, $options);
     }
 
     public function testPrepareOptionsDestinationNotSet(): void

--- a/tests/testThemeDir
+++ b/tests/testThemeDir
@@ -1,0 +1,1 @@
+../packages/ThemeDefault/


### PR DESCRIPTION
Here's an example of how you can test the themeDirectory configuration option. In this version, it will work, because I made it use Symfony 3.4 where this issue is fixed: symfony/symfony#23381 .

You might want to think about the following things though:

- Symfony 3.4 is not stable yet, so I had to reduce minimum-stability to make this work.
- The ApiGen documentation generation seems to use the same configuration file as the tests, so I had to change that file in order to be able to test the themeDirectory setting. In this case I just made a symlink to the normal theme directory, so it doesn't make a lot of difference...

Let me know if there's more I can do