### PR TITLE
[BUGFIX] Add string type hint

### DIFF
--- a/packages/Reflection/src/DocBlock/Tags/See.php
+++ b/packages/Reflection/src/DocBlock/Tags/See.php
@@ -45,7 +45,7 @@ final class See extends BaseTag implements StaticMethod
      * @param string $body
      */
     public static function create(
-        $body,
+        string $body,
         FqsenResolver $resolver = null,
         DescriptionFactory $descriptionFactory = null,
         TypeContext $context = null


### PR DESCRIPTION
The method header must be compatile to 
phpDocumentor\Reflection\DocBlock\Tag::create(string $body), therefore
adding a string type-hint to make it compatible.

Fixes #1035