### PR TITLE
add cache to avoid recurring reflection of classes

### DIFF
--- a/packages/BetterReflection/src/Reflector/CacheClassReflector.php
+++ b/packages/BetterReflection/src/Reflector/CacheClassReflector.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+namespace ApiGen\BetterReflection\Reflector;
+
+use Roave\BetterReflection\Reflection\Reflection;
+use Roave\BetterReflection\Reflector\ClassReflector;
+
+class CacheClassReflector extends ClassReflector
+{
+    private $reflectCache = [];
+
+    /**
+     * @inheritDoc
+     */
+    public function reflect(string $className): Reflection
+    {
+        if (isset($this->reflectCache[$className])) {
+            return $this->reflectCache[$className];
+        }
+        $class = parent::reflect($className);
+        $this->reflectCache[$className] = $class;
+
+        return $class;
+    }
+}

--- a/packages/BetterReflection/src/config/services.yml
+++ b/packages/BetterReflection/src/config/services.yml
@@ -4,6 +4,7 @@ services:
 
     ApiGen\BetterReflection\:
         resource: '..'
+        exclude: '../{Reflector}'
 
     # cached AST Locator
     Roave\BetterReflection\SourceLocator\Ast\PhpParserLocator: ~

--- a/packages/Reflection/src/Parser/Parser.php
+++ b/packages/Reflection/src/Parser/Parser.php
@@ -2,6 +2,7 @@
 
 namespace ApiGen\Reflection\Parser;
 
+use ApiGen\BetterReflection\Reflector\CacheClassReflector;
 use ApiGen\BetterReflection\SourceLocator\SourceLocatorsFactory;
 use ApiGen\Element\Cache\ReflectionWarmUpper;
 use ApiGen\Reflection\Contract\Reflection\Class_\ClassReflectionInterface;
@@ -186,14 +187,14 @@ final class Parser
 
     private function parseClassElements(SourceLocator $sourceLocator): void
     {
-        $classReflector = new ClassReflector($sourceLocator);
+        $classReflector = new CacheClassReflector($sourceLocator);
         $classInterfaceAndTraitReflections = $this->transformBetterClassInterfaceAndTraitReflections($classReflector);
         $this->separateClassInterfaceAndTraitReflections($classInterfaceAndTraitReflections);
     }
 
     private function parseFunctions(SourceLocator $sourceLocator): void
     {
-        $functionReflector = new FunctionReflector($sourceLocator, new ClassReflector($sourceLocator));
+        $functionReflector = new FunctionReflector($sourceLocator, new CacheClassReflector($sourceLocator));
         $functionReflections = $this->transformBetterFunctionReflections($functionReflector);
         $this->reflectionStorage->setFunctionReflections($functionReflections);
     }


### PR DESCRIPTION
I identified one of the bottlenecks in the parsing to be the parentClass resolver. As the reflected classes are not modified it should be possible to introduce a cache of reflected classes which speeds up the parsing a lot.