### PR TITLE
Make Bootstrap compatible with Nette\Schema 1.3

### DIFF
--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -158,7 +158,7 @@ class Bootstrap
 		foreach ($configs as $config) {
 			foreach ($config['parameters'] ?? [] as $key => $value) {
 				if (is_array($value)) {
-					$config['parameters'][$key][SchemaHelpers::PREVENT_MERGING] = true;
+					$config['parameters'][$key][SchemaHelpers::PreventMerging] = true;
 				}
 			}
 


### PR DESCRIPTION
Both variants are there in 1.2 but only the later in 1.3:
https://github.com/nette/schema/blob/v1.2/src/Schema/Helpers.php

Projects current composer dependency is set to ^1.2 so this should align the code with that.