### PR TITLE
Keep new lines in descriptions

### DIFF
--- a/src/Renderer/Latte/LatteFunctions.php
+++ b/src/Renderer/Latte/LatteFunctions.php
@@ -261,6 +261,6 @@ class LatteFunctions
 			}
 		}
 
-		return implode('\n', $text);
+		return implode("\n\n", $text);
 	}
 }


### PR DESCRIPTION
New lines are lost in descriptions, this breaks a lot of markdown code (titles, lists, code blocs, etc.) 

Space at the beginning of the first line of a bloc are also lost . which means that indentation is broken in code blocs if there's an empty line inside. not sure how to fix that one though :/